### PR TITLE
Add friendly ImportError when sqlalchemy is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ for event in response:
 ```
 
 > [!TIP]
+> For persistent database sessions, install the database extra: `pip install orxhestra[database]`
+
+> [!TIP]
 > For full documentation, guides, and API reference, visit [docs.orxhestra.com](https://docs.orxhestra.com).
 
 ## Features

--- a/docs/concepts/runner-sessions.mdx
+++ b/docs/concepts/runner-sessions.mdx
@@ -56,6 +56,21 @@ await svc.delete_session(session.id)
   Implement `BaseSessionService` to back sessions with any database. See [Architecture](/architecture#custom-session-backend) for an example.
 </Tip>
 
+## Database-backed sessions
+
+For production persistence, use `DatabaseSessionService` (requires `pip install orxhestra[database]`):
+
+```python
+from orxhestra.sessions import DatabaseSessionService
+
+svc = DatabaseSessionService("sqlite+aiosqlite:///sessions.db")
+await svc.initialize()
+
+session = await svc.create_session(app_name="demo", user_id="user-1")
+```
+
+Supports any SQLAlchemy async backend (SQLite via aiosqlite, PostgreSQL via asyncpg, etc.).
+
 ## Session Compaction
 
 Long conversations accumulate events that eventually exceed the LLM's context window. The Runner supports automatic **compaction** — summarizing old events into a single condensed event while keeping recent events intact.

--- a/orxhestra/sessions/database_session_service.py
+++ b/orxhestra/sessions/database_session_service.py
@@ -30,6 +30,13 @@ from orxhestra.events.event import Event
 from orxhestra.sessions.base_session_service import BaseSessionService
 from orxhestra.sessions.session import Session
 
+try:
+    import sqlalchemy  # noqa: F401
+
+    _HAS_SQLALCHEMY = True
+except ImportError:
+    _HAS_SQLALCHEMY = False
+
 
 class DatabaseSessionService(BaseSessionService):
     """Persistent session service backed by a SQL database.
@@ -46,6 +53,11 @@ class DatabaseSessionService(BaseSessionService):
     """
 
     def __init__(self, connection_string: str) -> None:
+        if not _HAS_SQLALCHEMY:
+            raise ImportError(
+                "DatabaseSessionService requires SQLAlchemy. "
+                "Install it with: pip install orxhestra[database]"
+            )
         self._connection_string = connection_string
         self._engine: Any = None
         self._initialized = False


### PR DESCRIPTION
## Summary

- Adds a guarded import check in `DatabaseSessionService.__init__` that raises a clear `ImportError` with install instructions (`pip install orxhestra[database]`) when sqlalchemy is not installed
- Documents `DatabaseSessionService` usage in `docs/concepts/runner-sessions.mdx` and adds a database extra tip to `README.md`

## Motivation

My AI coding agent kept failing when trying to use `DatabaseSessionService` — and because the error was just a raw `ModuleNotFoundError: No module named 'sqlalchemy'` with no guidance, the agent couldn't self-recover. I actually had to go read the source code myself to figure out there was an optional `[database]` extra. 

In 2026 we should expect our tools (and agents) to get actionable error messages they can act on without spelunking through library internals. A one-line install hint in the exception saves everyone a round-trip.

## Changes

| File | Change |
|------|--------|
| `orxhestra/sessions/database_session_service.py` | Module-level `_HAS_SQLALCHEMY` flag + guard in `__init__` |
| `docs/concepts/runner-sessions.mdx` | New "Database-backed sessions" section with usage example |
| `README.md` | Added tip about `pip install orxhestra[database]` |

No changes to `__init__.py` exports — the guard is non-raising at import time, so `from orxhestra import DatabaseSessionService` still works without sqlalchemy installed.

## Test plan

- [x] `uv run --extra database pytest tests/test_database_sessions.py` — all 10 tests pass
- [ ] Verify `python -c "from orxhestra import DatabaseSessionService"` works without sqlalchemy
- [ ] Verify `DatabaseSessionService("x")` raises the friendly `ImportError` without sqlalchemy

🤖 Generated with [Claude Code](https://claude.com/claude-code)