### PR TITLE
Refactor LlmAgent into composable modules

### DIFF
--- a/orxhestra/__init__.py
+++ b/orxhestra/__init__.py
@@ -38,7 +38,7 @@ Composer::
     from orxhestra.composer import Composer
 """
 
-__version__ = "0.0.37"
+__version__ = "0.0.38"
 
 from orxhestra.agents import (
     AgentConfig,

--- a/orxhestra/agents/callbacks.py
+++ b/orxhestra/agents/callbacks.py
@@ -1,0 +1,59 @@
+"""Grouped lifecycle callbacks for LlmAgent."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from orxhestra.agents.invocation_context import InvocationContext
+    from orxhestra.models.llm_request import LlmRequest
+    from orxhestra.models.llm_response import LlmResponse
+
+
+@dataclass
+class LlmAgentCallbacks:
+    """Grouped lifecycle callbacks for an LlmAgent.
+
+    Bundles the five optional hooks that LlmAgent supports so they
+    can be passed around as a single unit rather than five separate
+    constructor arguments.
+
+    Attributes
+    ----------
+    before_model : callable, optional
+        Called with ``(ctx, request)`` before each LLM call.
+    after_model : callable, optional
+        Called with ``(ctx, response)`` after each LLM call.
+    on_model_error : callable, optional
+        Called with ``(ctx, request, exception)`` when an LLM call
+        raises.  Return an ``LlmResponse`` to recover, or ``None``
+        to push an error event.
+    before_tool : callable, optional
+        Called with ``(ctx, tool_name, tool_args)`` before each tool
+        execution.
+    after_tool : callable, optional
+        Called with ``(ctx, tool_name, result)`` after each tool
+        execution.
+    """
+
+    before_model: (
+        Callable[[InvocationContext, LlmRequest], Awaitable[None]] | None
+    ) = None
+    after_model: (
+        Callable[[InvocationContext, LlmResponse], Awaitable[None]] | None
+    ) = None
+    on_model_error: (
+        Callable[
+            [InvocationContext, LlmRequest, Exception],
+            Awaitable[LlmResponse | None],
+        ]
+        | None
+    ) = None
+    before_tool: (
+        Callable[[InvocationContext, str, dict], Awaitable[None]] | None
+    ) = None
+    after_tool: (
+        Callable[[InvocationContext, str, Any], Awaitable[None]] | None
+    ) = None

--- a/orxhestra/agents/llm_agent.py
+++ b/orxhestra/agents/llm_agent.py
@@ -34,7 +34,6 @@ Context management:
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from functools import reduce
@@ -45,120 +44,33 @@ from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
     BaseMessage,
-    HumanMessage,
     SystemMessage,
     ToolMessage,
 )
-from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 
 from orxhestra.agents.base_agent import BaseAgent
+from orxhestra.agents.callbacks import LlmAgentCallbacks
 from orxhestra.agents.invocation_context import InvocationContext
-from orxhestra.concurrency import gather_with_event_queue
+from orxhestra.agents.message_builder import (
+    InstructionProvider,
+    MessageBuilder,
+    _truncate_tool_message,
+)
+from orxhestra.agents.planner_adapter import PlannerAdapter
+from orxhestra.agents.structured_output import StructuredOutputParser
+from orxhestra.agents.tool_executor import ToolExecutor
 from orxhestra.events.event import Event, EventType
 from orxhestra.events.event_actions import EventActions
-from orxhestra.events.filters import apply_compaction, should_include_event
 from orxhestra.models.llm_request import LlmRequest
 from orxhestra.models.llm_response import LlmResponse
-from orxhestra.models.part import (
-    Content,
-    DataPart,
-    TextPart,
-    ToolCallPart,
-    ToolResponsePart,
-)
-from orxhestra.tools.exit_loop import EXIT_LOOP_SENTINEL
-from orxhestra.tools.transfer_tool import TRANSFER_SENTINEL
+from orxhestra.models.part import Content, DataPart, TextPart
 
 if TYPE_CHECKING:
     from orxhestra.planners.base_planner import BasePlanner
 
 logger: logging.Logger = logging.getLogger(__name__)
-
-# Type alias for instruction providers - either a static string or a callable
-# that receives the current Context and returns a string.
-InstructionProvider = str | Callable[[InvocationContext], str | Awaitable[str]]
-
-_DEFAULT_INSTRUCTIONS = """\
-You are a helpful assistant. Answer the user's questions clearly and concisely.
-When you have enough information to answer, provide a direct response.
-Only use tools when necessary to complete the task.
-"""
-
-_PREV_CONTEXT_MAX_CHARS = 5000
-_PREV_CONTEXT_TOTAL_MAX_CHARS = 10_000
-
-# Maximum characters per tool response kept in the message history.
-_TOOL_RESPONSE_MAX_CHARS = 30_000
-
-
-def _build_previous_context(
-    events: list,
-    max_chars: int = _PREV_CONTEXT_MAX_CHARS,
-    total_max_chars: int = _PREV_CONTEXT_TOTAL_MAX_CHARS,
-) -> list[HumanMessage]:
-    """Build context messages from previous invocations' final responses.
-
-    Deduplicates by agent name (keeps only the latest response per agent)
-    and truncates long responses to prevent token explosion.
-
-    Parameters
-    ----------
-    events : list[Event]
-        Final response events from previous invocations
-        (from ``ctx.get_previous_final_responses()``).
-
-    Returns
-    -------
-    list[HumanMessage]
-        Context messages formatted as ``[agent] said: ...``.
-    """
-    from orxhestra.tools.output import truncate_output
-
-    if not events:
-        return []
-
-    # Deduplicate: keep only the LAST final response per agent
-    latest_by_agent: dict[str, Any] = {}
-    for event in events:
-        agent = event.agent_name or "agent"
-        latest_by_agent[agent] = event
-
-    # Build messages, truncating each and respecting total budget
-    messages: list[HumanMessage] = []
-    total_chars = 0
-
-    for agent, event in latest_by_agent.items():
-        if total_chars >= total_max_chars:
-            break
-
-        remaining = total_max_chars - total_chars
-        max_chars = min(max_chars, remaining)
-        text = truncate_output(event.text, max_chars)
-
-        content = f"[{agent}] said: {text}"
-        messages.append(HumanMessage(content=content))
-        total_chars += len(content)
-
-    return messages
-
-
-def _truncate_tool_message(
-    msg: ToolMessage, max_chars: int = _TOOL_RESPONSE_MAX_CHARS,
-) -> ToolMessage:
-    """Truncate a ToolMessage if its content exceeds the limit."""
-    content = msg.content
-    if isinstance(content, str) and len(content) > max_chars:
-        from orxhestra.tools.output import truncate_output
-
-        content = truncate_output(content, max_chars)
-        return ToolMessage(
-            content=content,
-            tool_call_id=msg.tool_call_id,
-        )
-    return msg
-
 
 class LlmAgent(BaseAgent):
     """Agent with a manual tool-call loop.
@@ -167,6 +79,15 @@ class LlmAgent(BaseAgent):
     static or dynamic system instructions, arbitrary LangChain tools,
     before/after callbacks at the model and tool level, an optional planner
     for per-turn planning instructions, and token-level streaming.
+
+    The heavy lifting is delegated to composable helpers:
+
+    * ``MessageBuilder`` — instruction resolution and history assembly.
+    * ``ToolExecutor`` — concurrent tool execution with event streaming.
+    * ``PlannerAdapter`` — prompt enrichment, response processing, and
+      continuation decisions.
+    * ``StructuredOutputParser`` — Pydantic output schema parsing.
+    * ``LlmAgentCallbacks`` — grouped lifecycle callbacks.
 
     Attributes
     ----------
@@ -180,42 +101,25 @@ class LlmAgent(BaseAgent):
         Planner that injects planning instructions before each LLM call.
     output_key : str, optional
         When set, the agent's final text answer is automatically saved
-        to ``ctx.state[output_key]``.  This makes the output available
-        to downstream agents via state (and ``{key}`` templating).
+        to ``ctx.state[output_key]``.
     output_schema : type, optional
         Optional Pydantic model for structured final output.
     include_contents : str
         Controls how much session history the agent sees:
 
         - ``'default'`` — full conversation history filtered by branch
-          and invocation (drops sibling agents' events and events from
-          other loop iterations).
-        - ``'none'`` — no prior history; agent operates solely on the
-          current input and its system instructions.  Ideal for
-          sub-agents that don't need conversation context.
+          and invocation.
+        - ``'none'`` — no prior history.
     max_iterations : int
         Maximum tool-call loop iterations before stopping.
-    before_model_callback : callable, optional
-        Called with ``(ctx, request: LlmRequest)`` before each LLM call.
-    after_model_callback : callable, optional
-        Called with ``(ctx, response: LlmResponse)`` after each LLM call.
-    on_model_error_callback : callable, optional
-        Called with ``(ctx, request: LlmRequest, exception)`` when an LLM
-        call raises. Return a ``LlmResponse`` to recover, or ``None`` to
-        push an error event.
-    before_tool_callback : callable, optional
-        Called with ``(ctx, tool_name, tool_args)`` before each tool execution.
-    after_tool_callback : callable, optional
-        Called with ``(ctx, tool_name, result)`` after each tool execution.
+    callbacks : LlmAgentCallbacks
+        Grouped lifecycle callbacks for model and tool events.
     tool_response_max_chars : int
         Max characters kept per tool response in message history.
-        Default 30,000 (~7.5k tokens).
     context_max_chars : int
         Max characters per previous agent response in context.
-        Default 5,000 (~1.25k tokens).
     context_total_max_chars : int
         Total character budget for all previous agent responses.
-        Default 10,000 (~2.5k tokens).
     """
 
     def __init__(
@@ -224,7 +128,7 @@ class LlmAgent(BaseAgent):
         llm: BaseChatModel,
         tools: list[BaseTool] | None = None,
         *,
-        instructions: InstructionProvider = _DEFAULT_INSTRUCTIONS,
+        instructions: InstructionProvider | None = None,
         description: str = "",
         planner: BasePlanner | None = None,
         output_key: str | None = None,
@@ -250,131 +154,124 @@ class LlmAgent(BaseAgent):
         after_tool_callback: (
             Callable[[InvocationContext, str, Any], Awaitable[None]] | None
         ) = None,
-        tool_response_max_chars: int = _TOOL_RESPONSE_MAX_CHARS,
-        context_max_chars: int = _PREV_CONTEXT_MAX_CHARS,
-        context_total_max_chars: int = _PREV_CONTEXT_TOTAL_MAX_CHARS,
+        tool_response_max_chars: int = 30_000,
+        context_max_chars: int = 5_000,
+        context_total_max_chars: int = 10_000,
     ) -> None:
         super().__init__(name=name, description=description)
+
         self._llm = llm
         self._tools: dict[str, BaseTool] = {t.name: t for t in (tools or [])}
         self._instructions = instructions
-        self._planner = planner
         self._output_key = output_key
         self._output_schema = output_schema
-        self._include_contents = include_contents
         self.max_iterations = max_iterations
+
+        # Expose limits for test assertions.
         self.tool_response_max_chars = tool_response_max_chars
         self.context_max_chars = context_max_chars
         self.context_total_max_chars = context_total_max_chars
-        self.before_model_callback = before_model_callback
-        self.after_model_callback = after_model_callback
-        self.on_model_error_callback = on_model_error_callback
-        self.before_tool_callback = before_tool_callback
-        self.after_tool_callback = after_tool_callback
 
-    # ── Prompt & history helpers ─────────────────────────────────
+        # Compose helpers.
+        self._callbacks = LlmAgentCallbacks(
+            before_model=before_model_callback,
+            after_model=after_model_callback,
+            on_model_error=on_model_error_callback,
+            before_tool=before_tool_callback,
+            after_tool=after_tool_callback,
+        )
+        # Use the default prompt when no instructions are provided.
+        from orxhestra.agents.message_builder import _DEFAULT_INSTRUCTIONS
+
+        effective_instructions: InstructionProvider = (
+            _DEFAULT_INSTRUCTIONS if instructions is None else instructions
+        )
+        self._message_builder = MessageBuilder(
+            instructions=effective_instructions,
+            output_schema=output_schema,
+            include_contents=include_contents,
+            context_max_chars=context_max_chars,
+            context_total_max_chars=context_total_max_chars,
+            tool_response_max_chars=tool_response_max_chars,
+        )
+        self._tool_executor = ToolExecutor(
+            tools=self._tools,
+            callbacks=self._callbacks,
+            emit_event=self._emit_event,
+        )
+        self._planner_adapter: PlannerAdapter | None = (
+            PlannerAdapter(planner) if planner else None
+        )
+        # Keep raw reference for subclass access (e.g. ReActAgent).
+        self._planner = planner
+        self._structured_parser: StructuredOutputParser | None = (
+            StructuredOutputParser(llm, output_schema)
+            if output_schema
+            else None
+        )
+
+    # ── Backward-compatible callback properties ─────────────────
+
+    @property
+    def before_model_callback(self) -> Callable[..., Any] | None:
+        """Before-model callback."""
+        return self._callbacks.before_model
+
+    @property
+    def after_model_callback(self) -> Callable[..., Any] | None:
+        """After-model callback."""
+        return self._callbacks.after_model
+
+    @property
+    def on_model_error_callback(self) -> Callable[..., Any] | None:
+        """On-model-error callback."""
+        return self._callbacks.on_model_error
+
+    @property
+    def before_tool_callback(self) -> Callable[..., Any] | None:
+        """Before-tool callback."""
+        return self._callbacks.before_tool
+
+    @property
+    def after_tool_callback(self) -> Callable[..., Any] | None:
+        """After-tool callback."""
+        return self._callbacks.after_tool
+
+    # ── Instruction resolution (kept for subclass access) ───────
 
     async def _resolve_instructions(self, ctx: InvocationContext) -> str:
-        """Resolve the system prompt from a string or instruction provider.
+        """Resolve the system prompt.
 
-        Supports ``{key}`` template substitution from ``ctx.state``.
-        Unknown keys are left as-is (no KeyError).
-        """
-        if callable(self._instructions):
-            result = self._instructions(ctx)
-            if asyncio.iscoroutine(result):
-                prompt = await result
-            else:
-                prompt = result
-        else:
-            prompt = self._instructions
-
-        # Template substitution: replace {key} with values from ctx.state.
-        if ctx.state and "{" in prompt:
-
-            class _DefaultDict(dict):
-                def __missing__(self, key: str) -> str:
-                    return "{" + key + "}"
-
-            prompt = prompt.format_map(_DefaultDict(ctx.state))
-
-        if self._output_schema is not None:
-            parser = PydanticOutputParser(pydantic_object=self._output_schema)
-            prompt = f"{prompt}\n\n{parser.get_format_instructions()}"
-
-        return prompt
-
-    async def _build_conversation_history(
-        self, ctx: InvocationContext, input: str,
-    ) -> tuple[str, list[BaseMessage]]:
-        """Build the system prompt and full message list for the LLM.
+        Delegates to ``MessageBuilder.resolve_instructions``.  Kept as
+        a method so subclasses (e.g. ``ReActAgent``) can call it.
 
         Parameters
         ----------
         ctx : InvocationContext
-            The current invocation context.
-        input : str
-            The user message or task description.
+            Current invocation context.
 
         Returns
         -------
-        tuple[str, list[BaseMessage]]
-            Resolved system prompt and the conversation messages.
+        str
+            The fully resolved system prompt.
         """
-        system_prompt = await self._resolve_instructions(ctx)
-        messages: list[BaseMessage] = []
-        if system_prompt:
-            messages.append(SystemMessage(content=system_prompt))
+        return await self._message_builder.resolve_instructions(ctx)
 
-        if self._include_contents != "none":
-            prev_responses = ctx.get_previous_final_responses()
-            prev_messages = _build_previous_context(
-                prev_responses,
-                max_chars=self.context_max_chars,
-                total_max_chars=self.context_total_max_chars,
-            )
-            messages.extend(prev_messages)
-
-            filtered = ctx.get_events(
-                current_branch=bool(ctx.branch),
-                current_invocation=bool(ctx.branch),
-            )
-            inv_id = ctx.invocation_id
-            filtered = [e for e in filtered if e.invocation_id != inv_id]
-            if filtered:
-                messages.extend(self._events_to_messages(filtered))
-
-        messages.append(HumanMessage(content=input))
-        return system_prompt, messages
-
-    # ── LLM helpers ──────────────────────────────────────────────
+    # ── LLM helpers ─────────────────────────────────────────────
 
     def _build_bound_llm(self) -> BaseChatModel:
         """Return the LLM with tools bound."""
-        llm = self._llm
+        llm: BaseChatModel = self._llm
         if self._tools:
             llm = llm.bind_tools(list(self._tools.values()))
         return llm
-
-    def _build_structured_llm(self) -> Any:
-        """Return the LLM bound with structured output for the final answer."""
-        if self._output_schema is None:
-            return None
-        for method in ("json_schema", "json_mode"):
-            try:
-                return self._llm.with_structured_output(
-                    self._output_schema, method=method
-                )
-            except (NotImplementedError, TypeError, ValueError):
-                continue
-        return None
 
     def _build_request(
         self,
         system_instruction: str,
         messages: list[BaseMessage],
     ) -> LlmRequest:
-        """Package the current turn into an LlmRequest."""
+        """Package the current turn into an ``LlmRequest``."""
         return LlmRequest(
             model=getattr(self._llm, "model_name", None)
             or getattr(self._llm, "model", None),
@@ -385,78 +282,7 @@ class LlmAgent(BaseAgent):
             output_schema=self._output_schema,
         )
 
-    def _apply_planner_instruction(
-        self,
-        base_prompt: str,
-        ctx: InvocationContext,
-        request: LlmRequest,
-    ) -> str:
-        """Append the planner's instruction to the system prompt."""
-        if self._planner is None:
-            return base_prompt
-        from orxhestra.agents.readonly_context import ReadonlyContext
-
-        readonly = ReadonlyContext(ctx)
-        instruction = self._planner.build_planning_instruction(readonly, request)
-        if instruction:
-            return f"{base_prompt}\n\n{instruction}"
-        return base_prompt
-
-    def _events_to_messages(self, events: list[Event]) -> list[BaseMessage]:
-        """Convert session events to LangChain messages for multi-turn context.
-
-        Applies visibility filtering, compaction processing, and drops
-        tool call events whose calls lack a matching response (e.g. from
-        interrupted sessions).
-
-        Parameters
-        ----------
-        events : list[Event]
-            Session events, already filtered by branch/invocation.
-
-        Returns
-        -------
-        list[BaseMessage]
-            LangChain messages ready for the LLM.
-        """
-        # 1. Apply compaction — replace raw events with summaries
-        events = apply_compaction(events)
-
-        # 2. Build set of responded tool call IDs
-        responded_ids: set[str] = set()
-        for event in events:
-            if not event.partial and event.type == EventType.TOOL_RESPONSE:
-                for tr in event.content.tool_responses:
-                    if tr.tool_call_id:
-                        responded_ids.add(tr.tool_call_id)
-
-        # 3. Convert to messages with visibility filtering
-        messages: list[BaseMessage] = []
-        for event in events:
-            if not should_include_event(event):
-                continue
-            if event.type == EventType.USER_MESSAGE:
-                messages.append(event.to_langchain_message())
-            elif event.type == EventType.AGENT_MESSAGE:
-                if event.has_tool_calls:
-                    paired = [
-                        {"id": tc.tool_call_id, "name": tc.tool_name, "args": tc.args}
-                        for tc in event.tool_calls
-                        if tc.tool_call_id in responded_ids
-                    ]
-                    if paired:
-                        messages.append(AIMessage(content="", tool_calls=paired))
-                elif event.text:
-                    messages.append(event.to_langchain_message())
-            elif event.type == EventType.TOOL_RESPONSE:
-                msg = event.to_langchain_message()
-                messages.append(
-                    _truncate_tool_message(msg, self.tool_response_max_chars)
-                )
-
-        return messages
-
-    # ── LLM call with streaming ──────────────────────────────────
+    # ── LLM call with streaming ─────────────────────────────────
 
     async def _call_llm(
         self,
@@ -464,17 +290,16 @@ class LlmAgent(BaseAgent):
         messages: list[BaseMessage],
         ctx: InvocationContext,
     ) -> AsyncIterator[Event | AIMessage]:
-        """Call the LLM, yielding partial events and the final AIMessage.
+        """Call the LLM, yielding partial events and the final ``AIMessage``.
 
-        Yields partial AGENT_MESSAGE events for each text token as they
-        arrive, then yields the final accumulated AIMessage as the last item.
+        Yields partial ``AGENT_MESSAGE`` events for each text token as
+        they arrive, then yields the final accumulated ``AIMessage`` as
+        the last item.
         """
-        rc = ctx.run_config
-
         chunks: list[AIMessageChunk] = []
-        has_tool_calls = False
+        has_tool_calls: bool = False
 
-        async for chunk in llm.astream(messages, config=rc):
+        async for chunk in llm.astream(messages, config=ctx.run_config):
             chunks.append(chunk)
 
             if not has_tool_calls and (
@@ -486,7 +311,7 @@ class LlmAgent(BaseAgent):
             if has_tool_calls:
                 continue
 
-            chunk_text = ""
+            chunk_text: str = ""
             if isinstance(chunk.content, str):
                 chunk_text = chunk.content
             elif isinstance(chunk.content, list):
@@ -518,15 +343,17 @@ class LlmAgent(BaseAgent):
     ) -> AsyncIterator[Event | AIMessage | None]:
         """Call the LLM with error recovery, yielding partial events.
 
-        Yields partial ``Event`` objects during streaming, then yields the
-        final ``AIMessage`` as the last item. Yields ``None`` as the last
-        item if an unrecoverable error occurred (caller should return).
+        Yields partial ``Event`` objects during streaming, then yields
+        the final ``AIMessage`` as the last item.  Yields ``None`` as
+        the last item if an unrecoverable error occurred.
         """
         try:
             async for item in self._call_llm(llm, messages, ctx):
                 yield item
         except Exception as exc:
-            recovered = await self._handle_llm_error(ctx, request, exc)
+            recovered: AIMessage | None = await self._handle_llm_error(
+                ctx, request, exc
+            )
             if recovered is not None:
                 yield recovered
             else:
@@ -538,14 +365,16 @@ class LlmAgent(BaseAgent):
         request: LlmRequest,
         exc: Exception,
     ) -> AIMessage | None:
-        """Handle an LLM call error, returning a recovery message or None."""
-        if self.on_model_error_callback:
-            recovery = await self.on_model_error_callback(ctx, request, exc)
+        """Handle an LLM call error, returning a recovery message or ``None``."""
+        if self._callbacks.on_model_error:
+            recovery: LlmResponse | None = await self._callbacks.on_model_error(
+                ctx, request, exc
+            )
             if recovery is not None:
                 return AIMessage(content=recovery.text or "")
         return None
 
-    # ── Final response handling ──────────────────────────────────
+    # ── Final response handling ─────────────────────────────────
 
     async def _handle_final_response(
         self,
@@ -553,11 +382,11 @@ class LlmAgent(BaseAgent):
         messages: list[BaseMessage],
         llm_response: LlmResponse,
     ) -> Event | None:
-        """Build the final response event, or None to continue the loop.
+        """Build the final response event, or ``None`` to continue the loop.
 
-        Checks the planner for pending tasks (returns None to continue),
-        parses structured output if configured, saves to output_key,
-        and builds the final event.
+        Checks the planner for pending tasks (returns ``None`` to
+        continue), parses structured output if configured, saves to
+        ``output_key``, and builds the final event.
 
         Parameters
         ----------
@@ -571,34 +400,21 @@ class LlmAgent(BaseAgent):
         Returns
         -------
         Event or None
-            The final response event, or None if the planner wants
+            The final response event, or ``None`` if the planner wants
             the loop to continue.
         """
-        # Check if planner has pending tasks — continue the loop.
-        if self._planner is not None:
-            from orxhestra.agents.readonly_context import ReadonlyContext
-
-            readonly = ReadonlyContext(ctx)
-            if self._planner.has_pending_tasks(readonly):
-                messages.append(
-                    HumanMessage(
-                        content=(
-                            "You still have pending tasks on the task board. "
-                            "Continue working on the next task — call the "
-                            "appropriate tools to make progress."
-                        )
-                    )
-                )
+        if self._planner_adapter is not None:
+            if self._planner_adapter.should_continue(ctx, messages):
                 return None
 
-        answer_text = llm_response.text
+        answer_text: str | None = llm_response.text
         parts: list[TextPart | DataPart] = []
         if answer_text:
             parts.append(TextPart(text=answer_text))
 
         # Parse structured output if schema is set.
-        if self._output_schema is not None:
-            structured = await self._parse_structured_output(
+        if self._structured_parser is not None:
+            structured = await self._structured_parser.parse(
                 answer_text, messages, ctx
             )
             if structured is not None:
@@ -618,149 +434,7 @@ class LlmAgent(BaseAgent):
 
         return self._emit_event(ctx, EventType.AGENT_MESSAGE, **emit_kwargs)
 
-    async def _parse_structured_output(
-        self,
-        answer_text: str | None,
-        messages: list[BaseMessage],
-        ctx: InvocationContext,
-    ) -> Any:
-        """Try to parse structured output from the answer text."""
-        parser = PydanticOutputParser(pydantic_object=self._output_schema)
-        if answer_text:
-            try:
-                return parser.parse(answer_text)
-            except Exception:
-                pass
-        structured_llm = self._build_structured_llm()
-        if structured_llm is not None:
-            try:
-                return await structured_llm.ainvoke(
-                    messages, config=ctx.run_config,
-                )
-            except Exception:
-                pass
-        return None
-
-    # ── Tool execution ───────────────────────────────────────────
-
-    async def _execute_tool_calls(
-        self,
-        ctx: InvocationContext,
-        llm_response: LlmResponse,
-    ) -> AsyncIterator[Event | tuple[Event, ToolMessage]]:
-        """Execute tool calls in parallel, yielding events as they complete.
-
-        Yields
-        ------
-        Event
-            The initial tool call event and intermediate child events.
-        tuple[Event, ToolMessage]
-            Tool response event paired with its ToolMessage for history.
-        """
-        event_queue: asyncio.Queue[Event | None] = asyncio.Queue()
-
-        tool_ctx = ctx.model_copy(
-            update={"event_callback": event_queue.put_nowait}
-        )
-
-        # Yield the tool call event.
-        yield self._emit_event(
-            ctx,
-            EventType.AGENT_MESSAGE,
-            content=Content(parts=[
-                ToolCallPart(
-                    tool_call_id=tc["id"],
-                    tool_name=tc["name"],
-                    args=tc["args"],
-                    metadata={"interactive": True}
-                    if getattr(
-                        self._tools.get(tc["name"]), "interactive", False
-                    )
-                    else {},
-                )
-                for tc in llm_response.tool_calls
-            ]),
-            llm_response=llm_response,
-        )
-
-        async def _execute_one(tool_call: dict) -> tuple[Event, ToolMessage]:
-            """Execute a single tool call and return response event + message."""
-            t_name = tool_call["name"]
-            t_args = tool_call["args"]
-            t_id = tool_call["id"]
-
-            tool = self._tools.get(t_name)
-            if tool is None:
-                return self._tool_response(
-                    ctx, t_id, t_name,
-                    error=f"Tool '{t_name}' not found. "
-                    f"Available: {list(self._tools)}",
-                )
-
-            if hasattr(tool, "inject_context"):
-                tool.inject_context(tool_ctx)
-            if self.before_tool_callback:
-                await self.before_tool_callback(ctx, t_name, t_args)
-
-            try:
-                result = await tool.ainvoke(t_args, config=ctx.run_config)
-                if self.after_tool_callback:
-                    await self.after_tool_callback(ctx, t_name, result)
-                return self._tool_response(ctx, t_id, t_name, result=str(result))
-            except Exception as exc:
-                if self.after_tool_callback:
-                    await self.after_tool_callback(ctx, t_name, None)
-                return self._tool_response(ctx, t_id, t_name, error=str(exc))
-
-        # Run all tool calls concurrently, streaming intermediate events.
-        async for item in gather_with_event_queue(
-            [_execute_one(tc) for tc in llm_response.tool_calls],
-            event_queue,
-        ):
-            if isinstance(item, Event):
-                yield item
-            else:
-                yield item  # tuple[Event, ToolMessage]
-
-    def _tool_response(
-        self,
-        ctx: InvocationContext,
-        t_id: str,
-        t_name: str,
-        *,
-        result: str | None = None,
-        error: str | None = None,
-    ) -> tuple[Event, ToolMessage]:
-        """Build a tool response event and ToolMessage pair."""
-        part = ToolResponsePart(
-            tool_call_id=t_id,
-            tool_name=t_name,
-            result=result or "",
-            error=error,
-        )
-        actions = EventActions()
-        content_str = result or error or ""
-        if result and result.startswith(TRANSFER_SENTINEL):
-            actions = EventActions(
-                transfer_to_agent=result.removeprefix(TRANSFER_SENTINEL).strip()
-            )
-        elif result == EXIT_LOOP_SENTINEL:
-            actions = EventActions(escalate=True)
-        event = self._emit_event(
-            ctx,
-            EventType.TOOL_RESPONSE,
-            content=Content(parts=[part]),
-            actions=actions,
-        )
-        msg_kwargs = {"status": "error"} if error else {}
-        msg = ToolMessage(
-            content=content_str,
-            tool_call_id=t_id,
-            **msg_kwargs,
-        )
-        return (event, msg)
-
-    # ── Main loop ────────────────────────────────────────────────
+    # ── Main loop ───────────────────────────────────────────────
 
     async def astream(
         self,
@@ -781,7 +455,7 @@ class LlmAgent(BaseAgent):
         config : RunnableConfig, optional
             LangChain-compatible config dict (tags, callbacks, etc.).
         ctx : InvocationContext, optional
-            Invocation context. Auto-created if not provided.
+            Invocation context.  Auto-created if not provided.
 
         Yields
         ------
@@ -790,29 +464,30 @@ class LlmAgent(BaseAgent):
             tokens, tool call/response events, and the final answer.
         """
         ctx = self._ensure_ctx(config, ctx)
-        system_prompt, messages = await self._build_conversation_history(
-            ctx, input
+        system_prompt, messages = (
+            await self._message_builder.build_conversation_history(ctx, input)
         )
-        llm = self._build_bound_llm()
+        llm: BaseChatModel = self._build_bound_llm()
 
         for _ in range(self.max_iterations):
             if ctx.end_invocation:
                 return
 
             # Build request and apply planner instruction.
-            request = self._build_request(system_prompt, messages)
-            effective_prompt = self._apply_planner_instruction(
-                system_prompt, ctx, request
-            )
-            if effective_prompt != system_prompt:
-                if messages and isinstance(messages[0], SystemMessage):
-                    messages[0] = SystemMessage(content=effective_prompt)
+            request: LlmRequest = self._build_request(system_prompt, messages)
+            if self._planner_adapter is not None:
+                effective_prompt: str = self._planner_adapter.enrich_prompt(
+                    ctx, system_prompt, request
+                )
+                if effective_prompt != system_prompt:
+                    if messages and isinstance(messages[0], SystemMessage):
+                        messages[0] = SystemMessage(content=effective_prompt)
 
-            if self.before_model_callback:
-                await self.before_model_callback(ctx, request)
+            if self._callbacks.before_model:
+                await self._callbacks.before_model(ctx, request)
 
             # Log context size at debug level only.
-            total_chars = sum(len(str(m.content)) for m in messages)
+            total_chars: int = sum(len(str(m.content)) for m in messages)
             if total_chars > 200_000:
                 logger.debug(
                     "Message context is %d chars (~%dk tokens).",
@@ -828,7 +503,6 @@ class LlmAgent(BaseAgent):
                 if isinstance(item, AIMessage):
                     raw_response = item
                 elif item is None:
-                    # Unrecoverable error — emit error event and stop.
                     yield self._emit_event(
                         ctx,
                         EventType.AGENT_MESSAGE,
@@ -843,25 +517,20 @@ class LlmAgent(BaseAgent):
                 return
 
             # Post-process response.
-            llm_response = LlmResponse.from_ai_message(raw_response)
-            if self._planner is not None:
-                from orxhestra.agents.readonly_context import ReadonlyContext
-
-                readonly = ReadonlyContext(ctx)
-                replacement = self._planner.process_planning_response(
-                    readonly, llm_response
+            llm_response: LlmResponse = LlmResponse.from_ai_message(raw_response)
+            if self._planner_adapter is not None:
+                llm_response = self._planner_adapter.process_response(
+                    ctx, llm_response
                 )
-                if replacement is not None:
-                    llm_response = replacement
 
-            if self.after_model_callback:
-                await self.after_model_callback(ctx, llm_response)
+            if self._callbacks.after_model:
+                await self._callbacks.after_model(ctx, llm_response)
 
             messages.append(raw_response)
 
             # No tool calls → final answer or planner continuation.
             if not llm_response.has_tool_calls:
-                final_event = await self._handle_final_response(
+                final_event: Event | None = await self._handle_final_response(
                     ctx, messages, llm_response
                 )
                 if final_event is None:
@@ -871,7 +540,7 @@ class LlmAgent(BaseAgent):
 
             # Execute tool calls and collect ToolMessages.
             tool_messages: list[ToolMessage] = []
-            async for item in self._execute_tool_calls(ctx, llm_response):
+            async for item in self._tool_executor.execute(ctx, llm_response):
                 if isinstance(item, tuple):
                     event, tool_msg = item
                     yield event

--- a/orxhestra/agents/message_builder.py
+++ b/orxhestra/agents/message_builder.py
@@ -1,0 +1,308 @@
+"""MessageBuilder — builds LangChain messages from session state.
+
+Responsible for resolving instructions (static or dynamic), converting
+session events into LangChain messages, and assembling the full
+conversation history sent to the LLM on each turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.output_parsers import PydanticOutputParser
+
+from orxhestra.events.event import EventType
+from orxhestra.events.filters import apply_compaction, should_include_event
+
+if TYPE_CHECKING:
+    from orxhestra.agents.invocation_context import InvocationContext
+    from orxhestra.events.event import Event
+
+# Type alias for instruction providers — uses a string forward reference
+# because InvocationContext is behind TYPE_CHECKING.
+InstructionProvider = str | Callable[..., str | Awaitable[str]]
+
+_DEFAULT_INSTRUCTIONS = """\
+You are a helpful assistant. Answer the user's questions clearly and concisely.
+When you have enough information to answer, provide a direct response.
+Only use tools when necessary to complete the task.
+"""
+
+_PREV_CONTEXT_MAX_CHARS = 5000
+_PREV_CONTEXT_TOTAL_MAX_CHARS = 10_000
+
+# Maximum characters per tool response kept in the message history.
+_TOOL_RESPONSE_MAX_CHARS = 30_000
+
+
+def _build_previous_context(
+    events: list[Event],
+    max_chars: int = _PREV_CONTEXT_MAX_CHARS,
+    total_max_chars: int = _PREV_CONTEXT_TOTAL_MAX_CHARS,
+) -> list[HumanMessage]:
+    """Build context messages from previous invocations' final responses.
+
+    Deduplicates by agent name (keeps only the latest response per agent)
+    and truncates long responses to prevent token explosion.
+
+    Parameters
+    ----------
+    events : list[Event]
+        Final response events from previous invocations
+        (from ``ctx.get_previous_final_responses()``).
+    max_chars : int
+        Maximum characters per individual agent response.
+    total_max_chars : int
+        Total character budget across all agent responses.
+
+    Returns
+    -------
+    list[HumanMessage]
+        Context messages formatted as ``[agent] said: ...``.
+    """
+    from orxhestra.tools.output import truncate_output
+
+    if not events:
+        return []
+
+    # Deduplicate: keep only the LAST final response per agent
+    latest_by_agent: dict[str, Any] = {}
+    for event in events:
+        agent = event.agent_name or "agent"
+        latest_by_agent[agent] = event
+
+    # Build messages, truncating each and respecting total budget
+    messages: list[HumanMessage] = []
+    total_chars = 0
+
+    for agent, event in latest_by_agent.items():
+        if total_chars >= total_max_chars:
+            break
+
+        remaining = total_max_chars - total_chars
+        effective_max = min(max_chars, remaining)
+        text = truncate_output(event.text, effective_max)
+
+        content = f"[{agent}] said: {text}"
+        messages.append(HumanMessage(content=content))
+        total_chars += len(content)
+
+    return messages
+
+
+def _truncate_tool_message(
+    msg: ToolMessage, max_chars: int = _TOOL_RESPONSE_MAX_CHARS,
+) -> ToolMessage:
+    """Truncate a ToolMessage if its content exceeds the limit.
+
+    Parameters
+    ----------
+    msg : ToolMessage
+        The tool message to potentially truncate.
+    max_chars : int
+        Maximum character count for the content.
+
+    Returns
+    -------
+    ToolMessage
+        Original message if within limit, or a new truncated copy.
+    """
+    content = msg.content
+    if isinstance(content, str) and len(content) > max_chars:
+        from orxhestra.tools.output import truncate_output
+
+        content = truncate_output(content, max_chars)
+        return ToolMessage(
+            content=content,
+            tool_call_id=msg.tool_call_id,
+        )
+    return msg
+
+
+class MessageBuilder:
+    """Builds LangChain messages for an LlmAgent turn.
+
+    Handles instruction resolution (static strings, callables, template
+    substitution), session-event-to-message conversion (with visibility
+    filtering and compaction), and previous-invocation context injection.
+
+    Parameters
+    ----------
+    instructions : InstructionProvider
+        System prompt string or callable returning one.
+    output_schema : type, optional
+        Pydantic model whose format instructions are appended to the
+        system prompt.
+    include_contents : str
+        ``'default'`` loads full filtered history; ``'none'`` skips
+        history entirely.
+    context_max_chars : int
+        Max characters per previous agent response in context.
+    context_total_max_chars : int
+        Total character budget for all previous agent responses.
+    tool_response_max_chars : int
+        Max characters kept per tool response in message history.
+    """
+
+    def __init__(
+        self,
+        instructions: InstructionProvider = _DEFAULT_INSTRUCTIONS,
+        output_schema: type | None = None,
+        include_contents: str = "default",
+        context_max_chars: int = _PREV_CONTEXT_MAX_CHARS,
+        context_total_max_chars: int = _PREV_CONTEXT_TOTAL_MAX_CHARS,
+        tool_response_max_chars: int = _TOOL_RESPONSE_MAX_CHARS,
+    ) -> None:
+        self._instructions = instructions
+        self._output_schema = output_schema
+        self._include_contents = include_contents
+        self.context_max_chars = context_max_chars
+        self.context_total_max_chars = context_total_max_chars
+        self.tool_response_max_chars = tool_response_max_chars
+
+    async def resolve_instructions(self, ctx: InvocationContext) -> str:
+        """Resolve the system prompt from a string or instruction provider.
+
+        Supports ``{key}`` template substitution from ``ctx.state``.
+        Unknown keys are left as-is (no ``KeyError``).
+
+        Parameters
+        ----------
+        ctx : InvocationContext
+            Current invocation context (used for state templating and
+            as the argument to callable instruction providers).
+
+        Returns
+        -------
+        str
+            The fully resolved system prompt.
+        """
+        if callable(self._instructions):
+            result = self._instructions(ctx)
+            if asyncio.iscoroutine(result):
+                prompt: str = await result
+            else:
+                prompt = result
+        else:
+            prompt = self._instructions
+
+        # Template substitution: replace {key} with values from ctx.state.
+        if ctx.state and "{" in prompt:
+
+            class _DefaultDict(dict):
+                def __missing__(self, key: str) -> str:
+                    return "{" + key + "}"
+
+            prompt = prompt.format_map(_DefaultDict(ctx.state))
+
+        if self._output_schema is not None:
+            parser = PydanticOutputParser(pydantic_object=self._output_schema)
+            prompt = f"{prompt}\n\n{parser.get_format_instructions()}"
+
+        return prompt
+
+    async def build_conversation_history(
+        self, ctx: InvocationContext, input_text: str,
+    ) -> tuple[str, list[BaseMessage]]:
+        """Build the system prompt and full message list for the LLM.
+
+        Parameters
+        ----------
+        ctx : InvocationContext
+            The current invocation context.
+        input_text : str
+            The user message or task description.
+
+        Returns
+        -------
+        tuple[str, list[BaseMessage]]
+            Resolved system prompt and the conversation messages.
+        """
+        system_prompt: str = await self.resolve_instructions(ctx)
+        messages: list[BaseMessage] = []
+        if system_prompt:
+            messages.append(SystemMessage(content=system_prompt))
+
+        if self._include_contents != "none":
+            prev_responses = ctx.get_previous_final_responses()
+            prev_messages = _build_previous_context(
+                prev_responses,
+                max_chars=self.context_max_chars,
+                total_max_chars=self.context_total_max_chars,
+            )
+            messages.extend(prev_messages)
+
+            filtered = ctx.get_events(
+                current_branch=bool(ctx.branch),
+                current_invocation=bool(ctx.branch),
+            )
+            inv_id = ctx.invocation_id
+            filtered = [e for e in filtered if e.invocation_id != inv_id]
+            if filtered:
+                messages.extend(self.events_to_messages(filtered))
+
+        messages.append(HumanMessage(content=input_text))
+        return system_prompt, messages
+
+    def events_to_messages(self, events: list[Event]) -> list[BaseMessage]:
+        """Convert session events to LangChain messages for multi-turn context.
+
+        Applies visibility filtering, compaction processing, and drops
+        tool call events whose calls lack a matching response (e.g. from
+        interrupted sessions).
+
+        Parameters
+        ----------
+        events : list[Event]
+            Session events, already filtered by branch/invocation.
+
+        Returns
+        -------
+        list[BaseMessage]
+            LangChain messages ready for the LLM.
+        """
+        # 1. Apply compaction — replace raw events with summaries
+        events = apply_compaction(events)
+
+        # 2. Build set of responded tool call IDs
+        responded_ids: set[str] = set()
+        for event in events:
+            if not event.partial and event.type == EventType.TOOL_RESPONSE:
+                for tr in event.content.tool_responses:
+                    if tr.tool_call_id:
+                        responded_ids.add(tr.tool_call_id)
+
+        # 3. Convert to messages with visibility filtering
+        messages: list[BaseMessage] = []
+        for event in events:
+            if not should_include_event(event):
+                continue
+            if event.type == EventType.USER_MESSAGE:
+                messages.append(event.to_langchain_message())
+            elif event.type == EventType.AGENT_MESSAGE:
+                if event.has_tool_calls:
+                    paired = [
+                        {"id": tc.tool_call_id, "name": tc.tool_name, "args": tc.args}
+                        for tc in event.tool_calls
+                        if tc.tool_call_id in responded_ids
+                    ]
+                    if paired:
+                        messages.append(AIMessage(content="", tool_calls=paired))
+                elif event.text:
+                    messages.append(event.to_langchain_message())
+            elif event.type == EventType.TOOL_RESPONSE:
+                msg = event.to_langchain_message()
+                messages.append(
+                    _truncate_tool_message(msg, self.tool_response_max_chars)
+                )
+
+        return messages

--- a/orxhestra/agents/planner_adapter.py
+++ b/orxhestra/agents/planner_adapter.py
@@ -1,0 +1,137 @@
+"""PlannerAdapter — centralises all planner interactions for LlmAgent."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langchain_core.messages import BaseMessage, HumanMessage
+
+if TYPE_CHECKING:
+    from orxhestra.agents.invocation_context import InvocationContext
+    from orxhestra.models.llm_request import LlmRequest
+    from orxhestra.models.llm_response import LlmResponse
+    from orxhestra.planners.base_planner import BasePlanner
+
+
+class PlannerAdapter:
+    """Thin facade over a ``BasePlanner``.
+
+    Consolidates the three planner touch-points that were previously
+    scattered across ``LlmAgent`` into a single object:
+
+    * Enriching the system prompt before each LLM call.
+    * Post-processing the LLM response.
+    * Deciding whether the agent loop should continue.
+
+    Parameters
+    ----------
+    planner : BasePlanner
+        The underlying planner strategy.
+    """
+
+    def __init__(self, planner: BasePlanner) -> None:
+        self._planner = planner
+
+    # -- Expose underlying planner for subclass access (e.g. ReActAgent) --
+
+    @property
+    def planner(self) -> BasePlanner:
+        """Return the wrapped planner instance."""
+        return self._planner
+
+    # -- Public helpers used by LlmAgent ----------------------------------
+
+    def enrich_prompt(
+        self,
+        ctx: InvocationContext,
+        base_prompt: str,
+        request: LlmRequest,
+    ) -> str:
+        """Append the planner's instruction to *base_prompt*.
+
+        Parameters
+        ----------
+        ctx : InvocationContext
+            Current invocation context.
+        base_prompt : str
+            The system prompt before planner enrichment.
+        request : LlmRequest
+            The request being built for the LLM.
+
+        Returns
+        -------
+        str
+            Enriched prompt, or *base_prompt* unchanged when the
+            planner returns nothing.
+        """
+        from orxhestra.agents.readonly_context import ReadonlyContext
+
+        readonly = ReadonlyContext(ctx)
+        instruction = self._planner.build_planning_instruction(readonly, request)
+        if instruction:
+            return f"{base_prompt}\n\n{instruction}"
+        return base_prompt
+
+    def process_response(
+        self,
+        ctx: InvocationContext,
+        response: LlmResponse,
+    ) -> LlmResponse:
+        """Let the planner optionally transform the LLM response.
+
+        Parameters
+        ----------
+        ctx : InvocationContext
+            Current invocation context.
+        response : LlmResponse
+            The raw LLM response.
+
+        Returns
+        -------
+        LlmResponse
+            The (possibly replaced) response.
+        """
+        from orxhestra.agents.readonly_context import ReadonlyContext
+
+        readonly = ReadonlyContext(ctx)
+        replacement = self._planner.process_planning_response(readonly, response)
+        return replacement if replacement is not None else response
+
+    def should_continue(
+        self,
+        ctx: InvocationContext,
+        messages: list[BaseMessage],
+    ) -> bool:
+        """Check if the planner still has pending work.
+
+        When ``True``, a continuation prompt is appended to *messages*
+        so the LLM keeps working.
+
+        Parameters
+        ----------
+        ctx : InvocationContext
+            Current invocation context.
+        messages : list[BaseMessage]
+            Conversation messages (mutated in-place when continuing).
+
+        Returns
+        -------
+        bool
+            ``True`` if the loop should continue, ``False`` if the
+            agent may return its final answer.
+        """
+        from orxhestra.agents.readonly_context import ReadonlyContext
+
+        readonly = ReadonlyContext(ctx)
+        if self._planner.has_pending_tasks(readonly):
+            messages.append(
+                HumanMessage(
+                    content=(
+                        "You still have pending tasks on the task board. "
+                        "Continue working on the next task — call the "
+                        "appropriate tools to make progress."
+                    )
+                )
+            )
+            return True
+        return False

--- a/orxhestra/agents/structured_output.py
+++ b/orxhestra/agents/structured_output.py
@@ -1,0 +1,92 @@
+"""StructuredOutputParser — handles Pydantic-schema-based output parsing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import BaseMessage
+from langchain_core.output_parsers import PydanticOutputParser
+
+if TYPE_CHECKING:
+    from orxhestra.agents.invocation_context import InvocationContext
+
+
+class StructuredOutputParser:
+    """Parse or extract structured output from LLM responses.
+
+    First attempts to parse the raw text via ``PydanticOutputParser``.
+    If that fails, falls back to calling the LLM with
+    ``with_structured_output()`` for a dedicated extraction call.
+
+    Parameters
+    ----------
+    llm : BaseChatModel
+        The LangChain chat model (used for the fallback extraction).
+    output_schema : type
+        Pydantic model class defining the expected structure.
+    """
+
+    def __init__(self, llm: BaseChatModel, output_schema: type) -> None:
+        self._llm = llm
+        self._output_schema = output_schema
+
+    def build_structured_llm(self) -> Any | None:
+        """Return the LLM bound with structured output, or ``None``.
+
+        Tries ``json_schema`` then ``json_mode`` as the binding method.
+
+        Returns
+        -------
+        BaseChatModel or None
+            The bound LLM, or ``None`` if binding is unsupported.
+        """
+        for method in ("json_schema", "json_mode"):
+            try:
+                return self._llm.with_structured_output(
+                    self._output_schema, method=method
+                )
+            except (NotImplementedError, TypeError, ValueError):
+                continue
+        return None
+
+    async def parse(
+        self,
+        answer_text: str | None,
+        messages: list[BaseMessage],
+        ctx: InvocationContext,
+    ) -> Any | None:
+        """Try to parse structured output from the answer text.
+
+        Falls back to a dedicated LLM call when text parsing fails.
+
+        Parameters
+        ----------
+        answer_text : str or None
+            The raw text answer from the LLM.
+        messages : list[BaseMessage]
+            Conversation messages for the fallback extraction call.
+        ctx : InvocationContext
+            Current invocation context.
+
+        Returns
+        -------
+        Pydantic model instance or None
+            The parsed structured output, or ``None`` if parsing
+            fails entirely.
+        """
+        parser = PydanticOutputParser(pydantic_object=self._output_schema)
+        if answer_text:
+            try:
+                return parser.parse(answer_text)
+            except Exception:
+                pass
+        structured_llm: Any | None = self.build_structured_llm()
+        if structured_llm is not None:
+            try:
+                return await structured_llm.ainvoke(
+                    messages, config=ctx.run_config,
+                )
+            except Exception:
+                pass
+        return None

--- a/orxhestra/agents/tool_executor.py
+++ b/orxhestra/agents/tool_executor.py
@@ -1,0 +1,185 @@
+"""ToolExecutor — runs tool calls and builds response events."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import BaseTool
+
+from orxhestra.concurrency import gather_with_event_queue
+from orxhestra.events.event import Event, EventType
+from orxhestra.events.event_actions import EventActions
+from orxhestra.models.part import Content, ToolCallPart, ToolResponsePart
+from orxhestra.tools.exit_loop import EXIT_LOOP_SENTINEL
+from orxhestra.tools.transfer_tool import TRANSFER_SENTINEL
+
+if TYPE_CHECKING:
+    from orxhestra.agents.callbacks import LlmAgentCallbacks
+    from orxhestra.agents.invocation_context import InvocationContext
+    from orxhestra.models.llm_response import LlmResponse
+
+
+class ToolExecutor:
+    """Executes LLM tool calls in parallel and yields events.
+
+    Handles tool lookup, context injection, before/after callbacks,
+    sentinel interception (transfer and exit-loop), and concurrent
+    execution with real-time event streaming.
+
+    Parameters
+    ----------
+    tools : dict[str, BaseTool]
+        Name-keyed tool registry.
+    callbacks : LlmAgentCallbacks
+        Lifecycle callbacks for before/after tool execution.
+    emit_event : callable
+        The ``BaseAgent._emit_event`` method (or equivalent) used to
+        construct ``Event`` objects.
+    """
+
+    def __init__(
+        self,
+        tools: dict[str, BaseTool],
+        callbacks: LlmAgentCallbacks,
+        emit_event: Callable[..., Event],
+    ) -> None:
+        self._tools = tools
+        self._callbacks = callbacks
+        self._emit_event = emit_event
+
+    async def execute(
+        self,
+        ctx: InvocationContext,
+        llm_response: LlmResponse,
+    ) -> AsyncIterator[Event | tuple[Event, ToolMessage]]:
+        """Execute tool calls in parallel, yielding events as they complete.
+
+        Yields
+        ------
+        Event
+            The initial tool call event and intermediate child events.
+        tuple[Event, ToolMessage]
+            Tool response event paired with its ``ToolMessage`` for
+            appending to the conversation history.
+        """
+        event_queue: asyncio.Queue[Event | None] = asyncio.Queue()
+
+        tool_ctx: InvocationContext = ctx.model_copy(
+            update={"event_callback": event_queue.put_nowait}
+        )
+
+        # Yield the tool call event.
+        yield self._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content(parts=[
+                ToolCallPart(
+                    tool_call_id=tc["id"],
+                    tool_name=tc["name"],
+                    args=tc["args"],
+                    metadata={"interactive": True}
+                    if getattr(
+                        self._tools.get(tc["name"]), "interactive", False
+                    )
+                    else {},
+                )
+                for tc in llm_response.tool_calls
+            ]),
+            llm_response=llm_response,
+        )
+
+        async def _execute_one(tool_call: dict[str, Any]) -> tuple[Event, ToolMessage]:
+            """Execute a single tool call and return response event + message."""
+            t_name: str = tool_call["name"]
+            t_args: dict[str, Any] = tool_call["args"]
+            t_id: str = tool_call["id"]
+
+            tool: BaseTool | None = self._tools.get(t_name)
+            if tool is None:
+                return self._build_response(
+                    ctx, t_id, t_name,
+                    error=f"Tool '{t_name}' not found. "
+                    f"Available: {list(self._tools)}",
+                )
+
+            if hasattr(tool, "inject_context"):
+                tool.inject_context(tool_ctx)
+            if self._callbacks.before_tool:
+                await self._callbacks.before_tool(ctx, t_name, t_args)
+
+            try:
+                result = await tool.ainvoke(t_args, config=ctx.run_config)
+                if self._callbacks.after_tool:
+                    await self._callbacks.after_tool(ctx, t_name, result)
+                return self._build_response(ctx, t_id, t_name, result=str(result))
+            except Exception as exc:
+                if self._callbacks.after_tool:
+                    await self._callbacks.after_tool(ctx, t_name, None)
+                return self._build_response(ctx, t_id, t_name, error=str(exc))
+
+        # Run all tool calls concurrently, streaming intermediate events.
+        async for item in gather_with_event_queue(
+            [_execute_one(tc) for tc in llm_response.tool_calls],
+            event_queue,
+        ):
+            yield item
+
+    def _build_response(
+        self,
+        ctx: InvocationContext,
+        t_id: str,
+        t_name: str,
+        *,
+        result: str | None = None,
+        error: str | None = None,
+    ) -> tuple[Event, ToolMessage]:
+        """Build a tool response event and ``ToolMessage`` pair.
+
+        Parameters
+        ----------
+        ctx : InvocationContext
+            Current invocation context.
+        t_id : str
+            Tool call identifier.
+        t_name : str
+            Tool name.
+        result : str, optional
+            Successful tool result.
+        error : str, optional
+            Error message from tool execution.
+
+        Returns
+        -------
+        tuple[Event, ToolMessage]
+            The response event and corresponding LangChain message.
+        """
+        part = ToolResponsePart(
+            tool_call_id=t_id,
+            tool_name=t_name,
+            result=result or "",
+            error=error,
+        )
+        actions = EventActions()
+        content_str: str = result or error or ""
+        if result and result.startswith(TRANSFER_SENTINEL):
+            actions = EventActions(
+                transfer_to_agent=result.removeprefix(TRANSFER_SENTINEL).strip()
+            )
+        elif result == EXIT_LOOP_SENTINEL:
+            actions = EventActions(escalate=True)
+        event: Event = self._emit_event(
+            ctx,
+            EventType.TOOL_RESPONSE,
+            content=Content(parts=[part]),
+            actions=actions,
+        )
+        msg_kwargs: dict[str, str] = {"status": "error"} if error else {}
+        msg = ToolMessage(
+            content=content_str,
+            tool_call_id=t_id,
+            **msg_kwargs,
+        )
+        return (event, msg)

--- a/orxhestra/models/llm_request.py
+++ b/orxhestra/models/llm_request.py
@@ -11,12 +11,9 @@ LangChain internals and makes the full request loggable and testable.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-
-if TYPE_CHECKING:
-    pass
 
 
 class LlmRequest(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orxhestra"
-version = "0.0.37"
+version = "0.0.38"
 description = "Multi-Agent Orchestration Framework for Python"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_llm_agent_context_limits.py
+++ b/tests/test_llm_agent_context_limits.py
@@ -8,8 +8,8 @@ from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 
 from orxhestra.agents.invocation_context import InvocationContext as Context
-from orxhestra.agents.llm_agent import (
-    LlmAgent,
+from orxhestra.agents.llm_agent import LlmAgent
+from orxhestra.agents.message_builder import (
     _build_previous_context,
     _truncate_tool_message,
 )


### PR DESCRIPTION
## Summary
- Extract five focused modules from the monolithic `LlmAgent` (~900 → ~400 lines):
  - `callbacks.py` — `LlmAgentCallbacks` dataclass grouping the 5 lifecycle hooks
  - `message_builder.py` — instruction resolution, history assembly, event-to-message conversion
  - `tool_executor.py` — concurrent tool execution with sentinel handling
  - `planner_adapter.py` — consolidated planner interactions (was scattered across 3 methods)
  - `structured_output.py` — Pydantic schema parsing with LLM fallback
- Remove unused `TYPE_CHECKING` block from `llm_request.py`
- Fully backward-compatible: same constructor signature, same public API

## Test plan
- [x] All 331 existing tests pass
- [x] Ruff clean on `orxhestra/` and `tests/`
- [ ] CI passes (lint + tests on Python 3.10–3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)