### PR TITLE
Add auth module: crypto, JWT, SSRF

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,9 @@
       "Bash(xxd orxhestra/skills/load_skill_tool.py)",
       "Bash(python -m pytest)",
       "Bash(gh run:*)",
-      "Bash(git pull:*)"
+      "Bash(git pull:*)",
+      "Bash(pip install:*)",
+      "Bash(python -m pytest tests/test_tracing.py -v)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(gh run:*)",
       "Bash(git pull:*)",
       "Bash(pip install:*)",
-      "Bash(python -m pytest tests/test_tracing.py -v)"
+      "Bash(python -m pytest tests/test_tracing.py -v)",
+      "Bash(python -m pytest tests/ -v)"
     ]
   }
 }

--- a/orxhestra/agents/llm_agent.py
+++ b/orxhestra/agents/llm_agent.py
@@ -61,6 +61,7 @@ from orxhestra.agents.message_builder import (
 from orxhestra.agents.planner_adapter import PlannerAdapter
 from orxhestra.agents.structured_output import StructuredOutputParser
 from orxhestra.agents.tool_executor import ToolExecutor
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
 from orxhestra.events.event import Event, EventType
 from orxhestra.events.event_actions import EventActions
 from orxhestra.models.llm_request import LlmRequest
@@ -210,7 +211,6 @@ class LlmAgent(BaseAgent):
             else None
         )
 
-    # ── Backward-compatible callback properties ─────────────────
 
     @property
     def before_model_callback(self) -> Callable[..., Any] | None:
@@ -237,7 +237,6 @@ class LlmAgent(BaseAgent):
         """After-tool callback."""
         return self._callbacks.after_tool
 
-    # ── Instruction resolution (kept for subclass access) ───────
 
     async def _resolve_instructions(self, ctx: InvocationContext) -> str:
         """Resolve the system prompt.
@@ -257,7 +256,6 @@ class LlmAgent(BaseAgent):
         """
         return await self._message_builder.resolve_instructions(ctx)
 
-    # ── LLM helpers ─────────────────────────────────────────────
 
     def _build_bound_llm(self) -> BaseChatModel:
         """Return the LLM with tools bound."""
@@ -282,7 +280,6 @@ class LlmAgent(BaseAgent):
             output_schema=self._output_schema,
         )
 
-    # ── LLM call with streaming ─────────────────────────────────
 
     async def _call_llm(
         self,
@@ -374,7 +371,6 @@ class LlmAgent(BaseAgent):
                 return AIMessage(content=recovery.text or "")
         return None
 
-    # ── Final response handling ─────────────────────────────────
 
     async def _handle_final_response(
         self,
@@ -434,7 +430,6 @@ class LlmAgent(BaseAgent):
 
         return self._emit_event(ctx, EventType.AGENT_MESSAGE, **emit_kwargs)
 
-    # ── Main loop ───────────────────────────────────────────────
 
     async def astream(
         self,
@@ -464,102 +459,112 @@ class LlmAgent(BaseAgent):
             tokens, tool call/response events, and the final answer.
         """
         ctx = self._ensure_ctx(config, ctx)
-        system_prompt, messages = (
-            await self._message_builder.build_conversation_history(ctx, input)
+        ctx, _run_mgr = await start_agent_span(
+            ctx, self.name, "LlmAgent", {"input": input},
         )
-        llm: BaseChatModel = self._build_bound_llm()
 
-        for _ in range(self.max_iterations):
-            if ctx.end_invocation:
-                return
+        try:
+            system_prompt, messages = (
+                await self._message_builder.build_conversation_history(ctx, input)
+            )
+            llm: BaseChatModel = self._build_bound_llm()
 
-            # Build request and apply planner instruction.
-            request: LlmRequest = self._build_request(system_prompt, messages)
-            if self._planner_adapter is not None:
-                effective_prompt: str = self._planner_adapter.enrich_prompt(
-                    ctx, system_prompt, request
-                )
-                if effective_prompt != system_prompt:
-                    if messages and isinstance(messages[0], SystemMessage):
-                        messages[0] = SystemMessage(content=effective_prompt)
-
-            if self._callbacks.before_model:
-                await self._callbacks.before_model(ctx, request)
-
-            # Log context size at debug level only.
-            total_chars: int = sum(len(str(m.content)) for m in messages)
-            if total_chars > 200_000:
-                logger.debug(
-                    "Message context is %d chars (~%dk tokens).",
-                    total_chars,
-                    total_chars // 4000,
-                )
-
-            # Call LLM with error recovery.
-            raw_response: AIMessage | None = None
-            async for item in self._call_llm_with_recovery(
-                llm, messages, ctx, request
-            ):
-                if isinstance(item, AIMessage):
-                    raw_response = item
-                elif item is None:
-                    yield self._emit_event(
-                        ctx,
-                        EventType.AGENT_MESSAGE,
-                        content=Content.from_text("LLM call failed."),
-                        metadata={"error": True},
-                    )
+            for _ in range(self.max_iterations):
+                if ctx.end_invocation:
                     return
-                else:
-                    yield item  # partial event
 
-            if raw_response is None:
-                return
-
-            # Post-process response.
-            llm_response: LlmResponse = LlmResponse.from_ai_message(raw_response)
-            if self._planner_adapter is not None:
-                llm_response = self._planner_adapter.process_response(
-                    ctx, llm_response
-                )
-
-            if self._callbacks.after_model:
-                await self._callbacks.after_model(ctx, llm_response)
-
-            messages.append(raw_response)
-
-            # No tool calls → final answer or planner continuation.
-            if not llm_response.has_tool_calls:
-                final_event: Event | None = await self._handle_final_response(
-                    ctx, messages, llm_response
-                )
-                if final_event is None:
-                    continue
-                yield final_event
-                return
-
-            # Execute tool calls and collect ToolMessages.
-            tool_messages: list[ToolMessage] = []
-            async for item in self._tool_executor.execute(ctx, llm_response):
-                if isinstance(item, tuple):
-                    event, tool_msg = item
-                    yield event
-                    tool_messages.append(
-                        _truncate_tool_message(
-                            tool_msg, self.tool_response_max_chars
-                        )
+                # Build request and apply planner instruction.
+                request: LlmRequest = self._build_request(system_prompt, messages)
+                if self._planner_adapter is not None:
+                    effective_prompt: str = self._planner_adapter.enrich_prompt(
+                        ctx, system_prompt, request
                     )
-                else:
-                    yield item
+                    if effective_prompt != system_prompt:
+                        if messages and isinstance(messages[0], SystemMessage):
+                            messages[0] = SystemMessage(content=effective_prompt)
 
-            messages.extend(tool_messages)
+                if self._callbacks.before_model:
+                    await self._callbacks.before_model(ctx, request)
 
-        yield self._emit_event(
-            ctx,
-            EventType.AGENT_MESSAGE,
-            content=Content.from_text(
-                f"Max iterations ({self.max_iterations}) reached "
-                f"without a final answer."
-            ),
-            metadata={"error": True},
-        )
+                # Log context size at debug level only.
+                total_chars: int = sum(len(str(m.content)) for m in messages)
+                if total_chars > 200_000:
+                    logger.debug(
+                        "Message context is %d chars (~%dk tokens).",
+                        total_chars,
+                        total_chars // 4000,
+                    )
+
+                # Call LLM with error recovery.
+                raw_response: AIMessage | None = None
+                async for item in self._call_llm_with_recovery(
+                    llm, messages, ctx, request
+                ):
+                    if isinstance(item, AIMessage):
+                        raw_response = item
+                    elif item is None:
+                        yield self._emit_event(
+                            ctx,
+                            EventType.AGENT_MESSAGE,
+                            content=Content.from_text("LLM call failed."),
+                            metadata={"error": True},
+                        )
+                        return
+                    else:
+                        yield item  # partial event
+
+                if raw_response is None:
+                    return
+
+                # Post-process response.
+                llm_response: LlmResponse = LlmResponse.from_ai_message(raw_response)
+                if self._planner_adapter is not None:
+                    llm_response = self._planner_adapter.process_response(
+                        ctx, llm_response
+                    )
+
+                if self._callbacks.after_model:
+                    await self._callbacks.after_model(ctx, llm_response)
+
+                messages.append(raw_response)
+
+                # No tool calls → final answer or planner continuation.
+                if not llm_response.has_tool_calls:
+                    final_event: Event | None = await self._handle_final_response(
+                        ctx, messages, llm_response
+                    )
+                    if final_event is None:
+                        continue
+                    yield final_event
+                    return
+
+                # Execute tool calls and collect ToolMessages.
+                tool_messages: list[ToolMessage] = []
+                async for item in self._tool_executor.execute(ctx, llm_response):
+                    if isinstance(item, tuple):
+                        event, tool_msg = item
+                        yield event
+                        tool_messages.append(
+                            _truncate_tool_message(
+                                tool_msg, self.tool_response_max_chars
+                            )
+                        )
+                    else:
+                        yield item
+
+                messages.extend(tool_messages)
+
+            yield self._emit_event(
+                ctx,
+                EventType.AGENT_MESSAGE,
+                content=Content.from_text(
+                    f"Max iterations ({self.max_iterations}) reached "
+                    f"without a final answer."
+                ),
+                metadata={"error": True},
+            )
+        except BaseException as exc:
+            await error_agent_span(_run_mgr, exc)
+            raise
+        else:
+            await end_agent_span(_run_mgr)

--- a/orxhestra/agents/llm_agent.py
+++ b/orxhestra/agents/llm_agent.py
@@ -211,7 +211,6 @@ class LlmAgent(BaseAgent):
             else None
         )
 
-
     @property
     def before_model_callback(self) -> Callable[..., Any] | None:
         """Before-model callback."""
@@ -237,7 +236,6 @@ class LlmAgent(BaseAgent):
         """After-tool callback."""
         return self._callbacks.after_tool
 
-
     async def _resolve_instructions(self, ctx: InvocationContext) -> str:
         """Resolve the system prompt.
 
@@ -255,7 +253,6 @@ class LlmAgent(BaseAgent):
             The fully resolved system prompt.
         """
         return await self._message_builder.resolve_instructions(ctx)
-
 
     def _build_bound_llm(self) -> BaseChatModel:
         """Return the LLM with tools bound."""
@@ -279,7 +276,6 @@ class LlmAgent(BaseAgent):
             tools_dict=dict(self._tools),
             output_schema=self._output_schema,
         )
-
 
     async def _call_llm(
         self,
@@ -370,7 +366,6 @@ class LlmAgent(BaseAgent):
             if recovery is not None:
                 return AIMessage(content=recovery.text or "")
         return None
-
 
     async def _handle_final_response(
         self,
@@ -463,6 +458,7 @@ class LlmAgent(BaseAgent):
             ctx, self.name, "LlmAgent", {"input": input},
         )
 
+        _span_err: BaseException | None = None
         try:
             system_prompt, messages = (
                 await self._message_builder.build_conversation_history(ctx, input)
@@ -470,6 +466,7 @@ class LlmAgent(BaseAgent):
             llm: BaseChatModel = self._build_bound_llm()
 
             for _ in range(self.max_iterations):
+                # External kill switch — stop immediately without yielding.
                 if ctx.end_invocation:
                     return
 
@@ -564,7 +561,10 @@ class LlmAgent(BaseAgent):
                 metadata={"error": True},
             )
         except BaseException as exc:
-            await error_agent_span(_run_mgr, exc)
+            _span_err = exc
             raise
-        else:
-            await end_agent_span(_run_mgr)
+        finally:
+            if _span_err is not None:
+                await error_agent_span(_run_mgr, _span_err)
+            else:
+                await end_agent_span(_run_mgr)

--- a/orxhestra/agents/llm_agent.py
+++ b/orxhestra/agents/llm_agent.py
@@ -61,7 +61,7 @@ from orxhestra.agents.message_builder import (
 from orxhestra.agents.planner_adapter import PlannerAdapter
 from orxhestra.agents.structured_output import StructuredOutputParser
 from orxhestra.agents.tool_executor import ToolExecutor
-from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
+from orxhestra.agents.tracing import trace
 from orxhestra.events.event import Event, EventType
 from orxhestra.events.event_actions import EventActions
 from orxhestra.models.llm_request import LlmRequest
@@ -426,6 +426,7 @@ class LlmAgent(BaseAgent):
         return self._emit_event(ctx, EventType.AGENT_MESSAGE, **emit_kwargs)
 
 
+    @trace("LlmAgent")
     async def astream(
         self,
         input: str,
@@ -453,118 +454,103 @@ class LlmAgent(BaseAgent):
             Events emitted during execution, including partial streaming
             tokens, tool call/response events, and the final answer.
         """
-        ctx = self._ensure_ctx(config, ctx)
-        ctx, _run_mgr = await start_agent_span(
-            ctx, self.name, "LlmAgent", {"input": input},
+        system_prompt, messages = (
+            await self._message_builder.build_conversation_history(ctx, input)
         )
+        llm: BaseChatModel = self._build_bound_llm()
 
-        _span_err: BaseException | None = None
-        try:
-            system_prompt, messages = (
-                await self._message_builder.build_conversation_history(ctx, input)
-            )
-            llm: BaseChatModel = self._build_bound_llm()
+        for _ in range(self.max_iterations):
+            # External kill switch — stop immediately without yielding.
+            if ctx.end_invocation:
+                return
 
-            for _ in range(self.max_iterations):
-                # External kill switch — stop immediately without yielding.
-                if ctx.end_invocation:
+            # Build request and apply planner instruction.
+            request: LlmRequest = self._build_request(system_prompt, messages)
+            if self._planner_adapter is not None:
+                effective_prompt: str = self._planner_adapter.enrich_prompt(
+                    ctx, system_prompt, request
+                )
+                if effective_prompt != system_prompt:
+                    if messages and isinstance(messages[0], SystemMessage):
+                        messages[0] = SystemMessage(content=effective_prompt)
+
+            if self._callbacks.before_model:
+                await self._callbacks.before_model(ctx, request)
+
+            # Log context size at debug level only.
+            total_chars: int = sum(len(str(m.content)) for m in messages)
+            if total_chars > 200_000:
+                logger.debug(
+                    "Message context is %d chars (~%dk tokens).",
+                    total_chars,
+                    total_chars // 4000,
+                )
+
+            # Call LLM with error recovery.
+            raw_response: AIMessage | None = None
+            async for item in self._call_llm_with_recovery(
+                llm, messages, ctx, request
+            ):
+                if isinstance(item, AIMessage):
+                    raw_response = item
+                elif item is None:
+                    yield self._emit_event(
+                        ctx,
+                        EventType.AGENT_MESSAGE,
+                        content=Content.from_text("LLM call failed."),
+                        metadata={"error": True},
+                    )
                     return
+                else:
+                    yield item  # partial event
 
-                # Build request and apply planner instruction.
-                request: LlmRequest = self._build_request(system_prompt, messages)
-                if self._planner_adapter is not None:
-                    effective_prompt: str = self._planner_adapter.enrich_prompt(
-                        ctx, system_prompt, request
-                    )
-                    if effective_prompt != system_prompt:
-                        if messages and isinstance(messages[0], SystemMessage):
-                            messages[0] = SystemMessage(content=effective_prompt)
+            if raw_response is None:
+                return
 
-                if self._callbacks.before_model:
-                    await self._callbacks.before_model(ctx, request)
+            # Post-process response.
+            llm_response: LlmResponse = LlmResponse.from_ai_message(raw_response)
+            if self._planner_adapter is not None:
+                llm_response = self._planner_adapter.process_response(
+                    ctx, llm_response
+                )
 
-                # Log context size at debug level only.
-                total_chars: int = sum(len(str(m.content)) for m in messages)
-                if total_chars > 200_000:
-                    logger.debug(
-                        "Message context is %d chars (~%dk tokens).",
-                        total_chars,
-                        total_chars // 4000,
-                    )
+            if self._callbacks.after_model:
+                await self._callbacks.after_model(ctx, llm_response)
 
-                # Call LLM with error recovery.
-                raw_response: AIMessage | None = None
-                async for item in self._call_llm_with_recovery(
-                    llm, messages, ctx, request
-                ):
-                    if isinstance(item, AIMessage):
-                        raw_response = item
-                    elif item is None:
-                        yield self._emit_event(
-                            ctx,
-                            EventType.AGENT_MESSAGE,
-                            content=Content.from_text("LLM call failed."),
-                            metadata={"error": True},
+            messages.append(raw_response)
+
+            # No tool calls → final answer or planner continuation.
+            if not llm_response.has_tool_calls:
+                final_event: Event | None = await self._handle_final_response(
+                    ctx, messages, llm_response
+                )
+                if final_event is None:
+                    continue
+                yield final_event
+                return
+
+            # Execute tool calls and collect ToolMessages.
+            tool_messages: list[ToolMessage] = []
+            async for item in self._tool_executor.execute(ctx, llm_response):
+                if isinstance(item, tuple):
+                    event, tool_msg = item
+                    yield event
+                    tool_messages.append(
+                        _truncate_tool_message(
+                            tool_msg, self.tool_response_max_chars
                         )
-                        return
-                    else:
-                        yield item  # partial event
-
-                if raw_response is None:
-                    return
-
-                # Post-process response.
-                llm_response: LlmResponse = LlmResponse.from_ai_message(raw_response)
-                if self._planner_adapter is not None:
-                    llm_response = self._planner_adapter.process_response(
-                        ctx, llm_response
                     )
+                else:
+                    yield item
 
-                if self._callbacks.after_model:
-                    await self._callbacks.after_model(ctx, llm_response)
+            messages.extend(tool_messages)
 
-                messages.append(raw_response)
-
-                # No tool calls → final answer or planner continuation.
-                if not llm_response.has_tool_calls:
-                    final_event: Event | None = await self._handle_final_response(
-                        ctx, messages, llm_response
-                    )
-                    if final_event is None:
-                        continue
-                    yield final_event
-                    return
-
-                # Execute tool calls and collect ToolMessages.
-                tool_messages: list[ToolMessage] = []
-                async for item in self._tool_executor.execute(ctx, llm_response):
-                    if isinstance(item, tuple):
-                        event, tool_msg = item
-                        yield event
-                        tool_messages.append(
-                            _truncate_tool_message(
-                                tool_msg, self.tool_response_max_chars
-                            )
-                        )
-                    else:
-                        yield item
-
-                messages.extend(tool_messages)
-
-            yield self._emit_event(
-                ctx,
-                EventType.AGENT_MESSAGE,
-                content=Content.from_text(
-                    f"Max iterations ({self.max_iterations}) reached "
-                    f"without a final answer."
-                ),
-                metadata={"error": True},
-            )
-        except BaseException as exc:
-            _span_err = exc
-            raise
-        finally:
-            if _span_err is not None:
-                await error_agent_span(_run_mgr, _span_err)
-            else:
-                await end_agent_span(_run_mgr)
+        yield self._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text(
+                f"Max iterations ({self.max_iterations}) reached "
+                f"without a final answer."
+            ),
+            metadata={"error": True},
+        )

--- a/orxhestra/agents/loop_agent.py
+++ b/orxhestra/agents/loop_agent.py
@@ -15,6 +15,7 @@ from langchain_core.runnables import RunnableConfig
 
 from orxhestra.agents.base_agent import BaseAgent
 from orxhestra.agents.invocation_context import InvocationContext
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
 from orxhestra.events.event import Event, EventType
 from orxhestra.models.part import Content
 
@@ -94,50 +95,60 @@ class LoopAgent(BaseAgent):
             is reached, or ``should_continue`` returns False.
         """
         ctx = self._ensure_ctx(config, ctx)
+        ctx, _run_mgr = await start_agent_span(
+            ctx, self.name, "LoopAgent", {"input": input},
+        )
 
         if not self.sub_agents:
+            await end_agent_span(_run_mgr)
             return
 
         iteration = 0
         last_event: Event | None = None
 
-        while True:
-            if ctx.end_invocation:
-                return
-
-            if self.max_iterations is not None and iteration >= self.max_iterations:
-                yield self._emit_event(
-                    ctx,
-                    EventType.AGENT_MESSAGE,
-                    content=Content.from_text(
-                        f"LoopAgent '{self.name}' reached max_iterations "
-                        f"({self.max_iterations}) without escalating."
-                    ),
-                    metadata={"error": True},
-                )
-                return
-
-            for sub_agent in self.sub_agents:
-                # Unique branch per iteration so the child's LLM doesn't
-                # re-read conversation history from previous iterations
-                child_ctx = ctx.derive(
-                    agent_name=sub_agent.name,
-                    branch_suffix=f"{sub_agent.name}.iter_{iteration}",
-                )
-                async for event in sub_agent.astream(input, ctx=child_ctx):
-                    yield event
-                    last_event = event
-
-                    if event.actions.escalate:
-                        return
-
-            # Custom termination check
-            if self.should_continue is not None and last_event is not None:
-                if not self.should_continue(last_event):
+        try:
+            while True:
+                if ctx.end_invocation:
                     return
 
-            # Reset sub-agent states between iterations so children
-            # start fresh each loop cycle.
-            ctx.reset_sub_agent_states(self.name)
+                if self.max_iterations is not None and iteration >= self.max_iterations:
+                    yield self._emit_event(
+                        ctx,
+                        EventType.AGENT_MESSAGE,
+                        content=Content.from_text(
+                            f"LoopAgent '{self.name}' reached max_iterations "
+                            f"({self.max_iterations}) without escalating."
+                        ),
+                        metadata={"error": True},
+                    )
+                    return
 
-            iteration += 1
+                for sub_agent in self.sub_agents:
+                    # Unique branch per iteration so the child's LLM doesn't
+                    # re-read conversation history from previous iterations
+                    child_ctx = ctx.derive(
+                        agent_name=sub_agent.name,
+                        branch_suffix=f"{sub_agent.name}.iter_{iteration}",
+                    )
+                    async for event in sub_agent.astream(input, ctx=child_ctx):
+                        yield event
+                        last_event = event
+
+                        if event.actions.escalate:
+                            return
+
+                # Custom termination check
+                if self.should_continue is not None and last_event is not None:
+                    if not self.should_continue(last_event):
+                        return
+
+                # Reset sub-agent states between iterations so children
+                # start fresh each loop cycle.
+                ctx.reset_sub_agent_states(self.name)
+
+                iteration += 1
+        except BaseException as exc:
+            await error_agent_span(_run_mgr, exc)
+            raise
+        else:
+            await end_agent_span(_run_mgr)

--- a/orxhestra/agents/loop_agent.py
+++ b/orxhestra/agents/loop_agent.py
@@ -15,7 +15,7 @@ from langchain_core.runnables import RunnableConfig
 
 from orxhestra.agents.base_agent import BaseAgent
 from orxhestra.agents.invocation_context import InvocationContext
-from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
+from orxhestra.agents.tracing import trace
 from orxhestra.events.event import Event, EventType
 from orxhestra.models.part import Content
 
@@ -59,6 +59,7 @@ class LoopAgent(BaseAgent):
         self.max_iterations = max_iterations
         self.should_continue = should_continue
 
+    @trace("LoopAgent")
     async def astream(
         self,
         input: str,
@@ -94,65 +95,49 @@ class LoopAgent(BaseAgent):
             The loop stops when a sub-agent escalates, ``max_iterations``
             is reached, or ``should_continue`` returns False.
         """
-        ctx = self._ensure_ctx(config, ctx)
-        ctx, _run_mgr = await start_agent_span(
-            ctx, self.name, "LoopAgent", {"input": input},
-        )
-
         if not self.sub_agents:
-            await end_agent_span(_run_mgr)
             return
 
         iteration = 0
         last_event: Event | None = None
 
-        _span_err: BaseException | None = None
-        try:
-            while True:
-                if ctx.end_invocation:
-                    return
+        while True:
+            if ctx.end_invocation:
+                return
 
-                if self.max_iterations is not None and iteration >= self.max_iterations:
-                    yield self._emit_event(
-                        ctx,
-                        EventType.AGENT_MESSAGE,
-                        content=Content.from_text(
-                            f"LoopAgent '{self.name}' reached max_iterations "
-                            f"({self.max_iterations}) without escalating."
-                        ),
-                        metadata={"error": True},
-                    )
-                    return
+            if self.max_iterations is not None and iteration >= self.max_iterations:
+                yield self._emit_event(
+                    ctx,
+                    EventType.AGENT_MESSAGE,
+                    content=Content.from_text(
+                        f"LoopAgent '{self.name}' reached max_iterations "
+                        f"({self.max_iterations}) without escalating."
+                    ),
+                    metadata={"error": True},
+                )
+                return
 
-                for sub_agent in self.sub_agents:
-                    # Unique branch per iteration so the child's LLM doesn't
-                    # re-read conversation history from previous iterations
-                    child_ctx = ctx.derive(
-                        agent_name=sub_agent.name,
-                        branch_suffix=f"{sub_agent.name}.iter_{iteration}",
-                    )
-                    async for event in sub_agent.astream(input, ctx=child_ctx):
-                        yield event
-                        last_event = event
+            for sub_agent in self.sub_agents:
+                # Unique branch per iteration so the child's LLM doesn't
+                # re-read conversation history from previous iterations
+                child_ctx = ctx.derive(
+                    agent_name=sub_agent.name,
+                    branch_suffix=f"{sub_agent.name}.iter_{iteration}",
+                )
+                async for event in sub_agent.astream(input, ctx=child_ctx):
+                    yield event
+                    last_event = event
 
-                        if event.actions.escalate:
-                            return
-
-                # Custom termination check
-                if self.should_continue is not None and last_event is not None:
-                    if not self.should_continue(last_event):
+                    if event.actions.escalate:
                         return
 
-                # Reset sub-agent states between iterations so children
-                # start fresh each loop cycle.
-                ctx.reset_sub_agent_states(self.name)
+            # Custom termination check
+            if self.should_continue is not None and last_event is not None:
+                if not self.should_continue(last_event):
+                    return
 
-                iteration += 1
-        except BaseException as exc:
-            _span_err = exc
-            raise
-        finally:
-            if _span_err is not None:
-                await error_agent_span(_run_mgr, _span_err)
-            else:
-                await end_agent_span(_run_mgr)
+            # Reset sub-agent states between iterations so children
+            # start fresh each loop cycle.
+            ctx.reset_sub_agent_states(self.name)
+
+            iteration += 1

--- a/orxhestra/agents/loop_agent.py
+++ b/orxhestra/agents/loop_agent.py
@@ -106,6 +106,7 @@ class LoopAgent(BaseAgent):
         iteration = 0
         last_event: Event | None = None
 
+        _span_err: BaseException | None = None
         try:
             while True:
                 if ctx.end_invocation:
@@ -148,7 +149,10 @@ class LoopAgent(BaseAgent):
 
                 iteration += 1
         except BaseException as exc:
-            await error_agent_span(_run_mgr, exc)
+            _span_err = exc
             raise
-        else:
-            await end_agent_span(_run_mgr)
+        finally:
+            if _span_err is not None:
+                await error_agent_span(_run_mgr, _span_err)
+            else:
+                await end_agent_span(_run_mgr)

--- a/orxhestra/agents/parallel_agent.py
+++ b/orxhestra/agents/parallel_agent.py
@@ -13,6 +13,7 @@ from langchain_core.runnables import RunnableConfig
 
 from orxhestra.agents.base_agent import BaseAgent
 from orxhestra.agents.invocation_context import InvocationContext
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
 from orxhestra.events.event import Event
 
 
@@ -65,8 +66,12 @@ class ParallelAgent(BaseAgent):
             branch path for attribution.
         """
         ctx = self._ensure_ctx(config, ctx)
+        ctx, _run_mgr = await start_agent_span(
+            ctx, self.name, "ParallelAgent", {"input": input},
+        )
 
         if not self.sub_agents:
+            await end_agent_span(_run_mgr)
             return
 
         # Use an internal queue to merge concurrent streams
@@ -93,6 +98,11 @@ class ParallelAgent(BaseAgent):
                     yield event
 
             await asyncio.gather(*tasks)
+        except BaseException as exc:
+            await error_agent_span(_run_mgr, exc)
+            raise
+        else:
+            await end_agent_span(_run_mgr)
         finally:
             for t in tasks:
                 t.cancel()

--- a/orxhestra/agents/parallel_agent.py
+++ b/orxhestra/agents/parallel_agent.py
@@ -88,6 +88,7 @@ class ParallelAgent(BaseAgent):
             for agent in self.sub_agents
         ]
 
+        _span_err: BaseException | None = None
         try:
             done_count = 0
             while done_count < len(tasks):
@@ -99,10 +100,12 @@ class ParallelAgent(BaseAgent):
 
             await asyncio.gather(*tasks)
         except BaseException as exc:
-            await error_agent_span(_run_mgr, exc)
+            _span_err = exc
             raise
-        else:
-            await end_agent_span(_run_mgr)
         finally:
             for t in tasks:
                 t.cancel()
+            if _span_err is not None:
+                await error_agent_span(_run_mgr, _span_err)
+            else:
+                await end_agent_span(_run_mgr)

--- a/orxhestra/agents/parallel_agent.py
+++ b/orxhestra/agents/parallel_agent.py
@@ -13,7 +13,7 @@ from langchain_core.runnables import RunnableConfig
 
 from orxhestra.agents.base_agent import BaseAgent
 from orxhestra.agents.invocation_context import InvocationContext
-from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
+from orxhestra.agents.tracing import trace
 from orxhestra.events.event import Event
 
 
@@ -40,6 +40,7 @@ class ParallelAgent(BaseAgent):
         for agent in agents:
             self.register_sub_agent(agent)
 
+    @trace("ParallelAgent")
     async def astream(
         self,
         input: str,
@@ -65,13 +66,7 @@ class ParallelAgent(BaseAgent):
             they are produced. Each event carries the sub-agent's
             branch path for attribution.
         """
-        ctx = self._ensure_ctx(config, ctx)
-        ctx, _run_mgr = await start_agent_span(
-            ctx, self.name, "ParallelAgent", {"input": input},
-        )
-
         if not self.sub_agents:
-            await end_agent_span(_run_mgr)
             return
 
         # Use an internal queue to merge concurrent streams
@@ -88,7 +83,6 @@ class ParallelAgent(BaseAgent):
             for agent in self.sub_agents
         ]
 
-        _span_err: BaseException | None = None
         try:
             done_count = 0
             while done_count < len(tasks):
@@ -99,13 +93,6 @@ class ParallelAgent(BaseAgent):
                     yield event
 
             await asyncio.gather(*tasks)
-        except BaseException as exc:
-            _span_err = exc
-            raise
         finally:
             for t in tasks:
                 t.cancel()
-            if _span_err is not None:
-                await error_agent_span(_run_mgr, _span_err)
-            else:
-                await end_agent_span(_run_mgr)

--- a/orxhestra/agents/react_agent.py
+++ b/orxhestra/agents/react_agent.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 
 from orxhestra.agents.invocation_context import InvocationContext as Context
 from orxhestra.agents.llm_agent import LlmAgent
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
 from orxhestra.events.event import Event, EventType
 from orxhestra.models.part import Content, ToolCallPart, ToolResponsePart
 
@@ -246,118 +247,127 @@ class ReActAgent(LlmAgent):
             tool calls, observations, and the final answer.
         """
         ctx = self._ensure_ctx(config, ctx)
+        ctx, _run_mgr = await start_agent_span(
+            ctx, self.name, "ReActAgent", {"input": input},
+        )
 
-        system_prompt = await self._build_react_system_prompt(ctx)
-        messages: list[BaseMessage] = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=input),
-        ]
+        try:
+            system_prompt = await self._build_react_system_prompt(ctx)
+            messages: list[BaseMessage] = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=input),
+            ]
 
-        for _ in range(self.max_iterations):
-            step: ReActStep | None = None
-            try:
-                async for item in self._invoke_step(messages, ctx):
-                    if isinstance(item, ReActStep):
-                        step = item
-                    else:
-                        yield item
-            except Exception as exc:
+            for _ in range(self.max_iterations):
+                step: ReActStep | None = None
+                try:
+                    async for item in self._invoke_step(messages, ctx):
+                        if isinstance(item, ReActStep):
+                            step = item
+                        else:
+                            yield item
+                except Exception as exc:
+                    yield self._emit_event(
+                        ctx,
+                        EventType.AGENT_MESSAGE,
+                        content=Content.from_text(str(exc)),
+                        metadata={
+                            "error": True,
+                            "exception_type": type(exc).__name__,
+                        },
+                    )
+                    return
+
+                # Final answer
+                if step.is_final:
+                    yield self._emit_event(
+                        ctx,
+                        EventType.AGENT_MESSAGE,
+                        content=Content.from_text(step.answer),
+                        metadata={"scratchpad": step.scratchpad},
+                    )
+                    return
+
+                # Tool call
                 yield self._emit_event(
                     ctx,
                     EventType.AGENT_MESSAGE,
-                    content=Content.from_text(str(exc)),
                     metadata={
-                        "error": True,
-                        "exception_type": type(exc).__name__,
+                        "react_step": "action",
+                        "action": step.action,
+                        "action_input": step.action_input,
                     },
                 )
-                return
 
-            # Final answer
-            if step.is_final:
-                yield self._emit_event(
-                    ctx,
-                    EventType.AGENT_MESSAGE,
-                    content=Content.from_text(step.answer),
-                    metadata={"scratchpad": step.scratchpad},
-                )
-                return
-
-            # Tool call
-            yield self._emit_event(
-                ctx,
-                EventType.AGENT_MESSAGE,
-                metadata={
-                    "react_step": "action",
-                    "action": step.action,
-                    "action_input": step.action_input,
-                },
-            )
-
-            tool = self._tools.get(step.action)
-            if tool is None:
-                observation = f"Error: tool '{step.action}' not found."
-            else:
-                yield self._emit_event(
-                    ctx,
-                    EventType.AGENT_MESSAGE,
-                    content=Content(
-                        parts=[
-                            ToolCallPart(
-                                tool_call_id=f"react_{step.action}",
-                                tool_name=step.action,
-                                args={"input": step.action_input},
-                            )
-                        ]
-                    ),
-                )
-                try:
-                    result = await tool.ainvoke(step.action_input, config=ctx.run_config)
-                    observation = str(result)
+                tool = self._tools.get(step.action)
+                if tool is None:
+                    observation = f"Error: tool '{step.action}' not found."
+                else:
                     yield self._emit_event(
                         ctx,
-                        EventType.TOOL_RESPONSE,
+                        EventType.AGENT_MESSAGE,
                         content=Content(
                             parts=[
-                                ToolResponsePart(
+                                ToolCallPart(
                                     tool_call_id=f"react_{step.action}",
                                     tool_name=step.action,
-                                    result=observation,
+                                    args={"input": step.action_input},
                                 )
                             ]
                         ),
                     )
-                except Exception as exc:
-                    observation = f"Error: {exc}"
-                    yield self._emit_event(
-                        ctx,
-                        EventType.TOOL_RESPONSE,
-                        content=Content(
-                            parts=[
-                                ToolResponsePart(
-                                    tool_call_id=f"react_{step.action}",
-                                    tool_name=step.action,
-                                    error=str(exc),
-                                )
-                            ]
-                        ),
-                    )
+                    try:
+                        result = await tool.ainvoke(step.action_input, config=ctx.run_config)
+                        observation = str(result)
+                        yield self._emit_event(
+                            ctx,
+                            EventType.TOOL_RESPONSE,
+                            content=Content(
+                                parts=[
+                                    ToolResponsePart(
+                                        tool_call_id=f"react_{step.action}",
+                                        tool_name=step.action,
+                                        result=observation,
+                                    )
+                                ]
+                            ),
+                        )
+                    except Exception as exc:
+                        observation = f"Error: {exc}"
+                        yield self._emit_event(
+                            ctx,
+                            EventType.TOOL_RESPONSE,
+                            content=Content(
+                                parts=[
+                                    ToolResponsePart(
+                                        tool_call_id=f"react_{step.action}",
+                                        tool_name=step.action,
+                                        error=str(exc),
+                                    )
+                                ]
+                            ),
+                        )
+
+                yield self._emit_event(
+                    ctx,
+                    EventType.AGENT_MESSAGE,
+                    content=Content.from_text(observation),
+                    metadata={"react_step": "observation", "tool_name": step.action},
+                )
+
+                messages.append(AIMessage(content=str(step.model_dump())))
+                messages.append(HumanMessage(content=f"Observation: {observation}"))
 
             yield self._emit_event(
                 ctx,
                 EventType.AGENT_MESSAGE,
-                content=Content.from_text(observation),
-                metadata={"react_step": "observation", "tool_name": step.action},
+                content=Content.from_text(
+                    f"Max iterations ({self.max_iterations}) reached without a final answer."
+                ),
+                metadata={"error": True},
             )
-
-            messages.append(AIMessage(content=str(step.model_dump())))
-            messages.append(HumanMessage(content=f"Observation: {observation}"))
-
-        yield self._emit_event(
-            ctx,
-            EventType.AGENT_MESSAGE,
-            content=Content.from_text(
-                f"Max iterations ({self.max_iterations}) reached without a final answer."
-            ),
-            metadata={"error": True},
-        )
+        except BaseException as exc:
+            await error_agent_span(_run_mgr, exc)
+            raise
+        else:
+            await end_agent_span(_run_mgr)

--- a/orxhestra/agents/react_agent.py
+++ b/orxhestra/agents/react_agent.py
@@ -251,6 +251,7 @@ class ReActAgent(LlmAgent):
             ctx, self.name, "ReActAgent", {"input": input},
         )
 
+        _span_err: BaseException | None = None
         try:
             system_prompt = await self._build_react_system_prompt(ctx)
             messages: list[BaseMessage] = [
@@ -367,7 +368,10 @@ class ReActAgent(LlmAgent):
                 metadata={"error": True},
             )
         except BaseException as exc:
-            await error_agent_span(_run_mgr, exc)
+            _span_err = exc
             raise
-        else:
-            await end_agent_span(_run_mgr)
+        finally:
+            if _span_err is not None:
+                await error_agent_span(_run_mgr, _span_err)
+            else:
+                await end_agent_span(_run_mgr)

--- a/orxhestra/agents/react_agent.py
+++ b/orxhestra/agents/react_agent.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 
 from orxhestra.agents.invocation_context import InvocationContext as Context
 from orxhestra.agents.llm_agent import LlmAgent
-from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
+from orxhestra.agents.tracing import trace
 from orxhestra.events.event import Event, EventType
 from orxhestra.models.part import Content, ToolCallPart, ToolResponsePart
 
@@ -222,6 +222,7 @@ class ReActAgent(LlmAgent):
 
         yield step
 
+    @trace("ReActAgent")
     async def astream(
         self,
         input: str,
@@ -246,132 +247,117 @@ class ReActAgent(LlmAgent):
             Events emitted during execution, including thought steps,
             tool calls, observations, and the final answer.
         """
-        ctx = self._ensure_ctx(config, ctx)
-        ctx, _run_mgr = await start_agent_span(
-            ctx, self.name, "ReActAgent", {"input": input},
-        )
+        system_prompt = await self._build_react_system_prompt(ctx)
+        messages: list[BaseMessage] = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=input),
+        ]
 
-        _span_err: BaseException | None = None
-        try:
-            system_prompt = await self._build_react_system_prompt(ctx)
-            messages: list[BaseMessage] = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=input),
-            ]
-
-            for _ in range(self.max_iterations):
-                step: ReActStep | None = None
-                try:
-                    async for item in self._invoke_step(messages, ctx):
-                        if isinstance(item, ReActStep):
-                            step = item
-                        else:
-                            yield item
-                except Exception as exc:
-                    yield self._emit_event(
-                        ctx,
-                        EventType.AGENT_MESSAGE,
-                        content=Content.from_text(str(exc)),
-                        metadata={
-                            "error": True,
-                            "exception_type": type(exc).__name__,
-                        },
-                    )
-                    return
-
-                # Final answer
-                if step.is_final:
-                    yield self._emit_event(
-                        ctx,
-                        EventType.AGENT_MESSAGE,
-                        content=Content.from_text(step.answer),
-                        metadata={"scratchpad": step.scratchpad},
-                    )
-                    return
-
-                # Tool call
+        for _ in range(self.max_iterations):
+            step: ReActStep | None = None
+            try:
+                async for item in self._invoke_step(messages, ctx):
+                    if isinstance(item, ReActStep):
+                        step = item
+                    else:
+                        yield item
+            except Exception as exc:
                 yield self._emit_event(
                     ctx,
                     EventType.AGENT_MESSAGE,
+                    content=Content.from_text(str(exc)),
                     metadata={
-                        "react_step": "action",
-                        "action": step.action,
-                        "action_input": step.action_input,
+                        "error": True,
+                        "exception_type": type(exc).__name__,
                     },
                 )
+                return
 
-                tool = self._tools.get(step.action)
-                if tool is None:
-                    observation = f"Error: tool '{step.action}' not found."
-                else:
+            # Final answer
+            if step.is_final:
+                yield self._emit_event(
+                    ctx,
+                    EventType.AGENT_MESSAGE,
+                    content=Content.from_text(step.answer),
+                    metadata={"scratchpad": step.scratchpad},
+                )
+                return
+
+            # Tool call
+            yield self._emit_event(
+                ctx,
+                EventType.AGENT_MESSAGE,
+                metadata={
+                    "react_step": "action",
+                    "action": step.action,
+                    "action_input": step.action_input,
+                },
+            )
+
+            tool = self._tools.get(step.action)
+            if tool is None:
+                observation = f"Error: tool '{step.action}' not found."
+            else:
+                yield self._emit_event(
+                    ctx,
+                    EventType.AGENT_MESSAGE,
+                    content=Content(
+                        parts=[
+                            ToolCallPart(
+                                tool_call_id=f"react_{step.action}",
+                                tool_name=step.action,
+                                args={"input": step.action_input},
+                            )
+                        ]
+                    ),
+                )
+                try:
+                    result = await tool.ainvoke(step.action_input, config=ctx.run_config)
+                    observation = str(result)
                     yield self._emit_event(
                         ctx,
-                        EventType.AGENT_MESSAGE,
+                        EventType.TOOL_RESPONSE,
                         content=Content(
                             parts=[
-                                ToolCallPart(
+                                ToolResponsePart(
                                     tool_call_id=f"react_{step.action}",
                                     tool_name=step.action,
-                                    args={"input": step.action_input},
+                                    result=observation,
                                 )
                             ]
                         ),
                     )
-                    try:
-                        result = await tool.ainvoke(step.action_input, config=ctx.run_config)
-                        observation = str(result)
-                        yield self._emit_event(
-                            ctx,
-                            EventType.TOOL_RESPONSE,
-                            content=Content(
-                                parts=[
-                                    ToolResponsePart(
-                                        tool_call_id=f"react_{step.action}",
-                                        tool_name=step.action,
-                                        result=observation,
-                                    )
-                                ]
-                            ),
-                        )
-                    except Exception as exc:
-                        observation = f"Error: {exc}"
-                        yield self._emit_event(
-                            ctx,
-                            EventType.TOOL_RESPONSE,
-                            content=Content(
-                                parts=[
-                                    ToolResponsePart(
-                                        tool_call_id=f"react_{step.action}",
-                                        tool_name=step.action,
-                                        error=str(exc),
-                                    )
-                                ]
-                            ),
-                        )
-
-                yield self._emit_event(
-                    ctx,
-                    EventType.AGENT_MESSAGE,
-                    content=Content.from_text(observation),
-                    metadata={"react_step": "observation", "tool_name": step.action},
-                )
-
-                messages.append(AIMessage(content=str(step.model_dump())))
-                messages.append(HumanMessage(content=f"Observation: {observation}"))
+                except Exception as exc:
+                    observation = f"Error: {exc}"
+                    yield self._emit_event(
+                        ctx,
+                        EventType.TOOL_RESPONSE,
+                        content=Content(
+                            parts=[
+                                ToolResponsePart(
+                                    tool_call_id=f"react_{step.action}",
+                                    tool_name=step.action,
+                                    error=str(exc),
+                                )
+                            ]
+                        ),
+                    )
 
             yield self._emit_event(
                 ctx,
                 EventType.AGENT_MESSAGE,
-                content=Content.from_text(
-                    f"Max iterations ({self.max_iterations}) reached without a final answer."
-                ),
-                metadata={"error": True},
+                content=Content.from_text(observation),
+                metadata={"react_step": "observation", "tool_name": step.action},
             )
-        except BaseException as exc:
-            _span_err = exc
-            raise
-        finally:
-            if _span_err is not None:
-                await error_agent_span(_run_mgr, _span_err)
-            else:
-                await end_agent_span(_run_mgr)
+
+            messages.append(AIMessage(content=str(step.model_dump())))
+            messages.append(HumanMessage(content=f"Observation: {observation}"))
+
+        yield self._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text(
+                f"Max iterations ({self.max_iterations}) reached without a final answer."
+            ),
+            metadata={"error": True},
+        )

--- a/orxhestra/agents/sequential_agent.py
+++ b/orxhestra/agents/sequential_agent.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import RunnableConfig
 
 from orxhestra.agents.base_agent import BaseAgent
 from orxhestra.agents.invocation_context import InvocationContext
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
 from orxhestra.events.event import Event
 
 
@@ -68,18 +69,28 @@ class SequentialAgent(BaseAgent):
             receives the previous agent's final answer text as input.
         """
         ctx = self._ensure_ctx(config, ctx)
+        ctx, _run_mgr = await start_agent_span(
+            ctx, self.name, "SequentialAgent", {"input": input},
+        )
 
         if not self.sub_agents:
+            await end_agent_span(_run_mgr)
             return
 
         current_input = input
 
-        for sub_agent in self.sub_agents:
-            if ctx.end_invocation:
-                return
-            child_ctx = ctx.derive(agent_name=sub_agent.name)
-            async for event in sub_agent.astream(current_input, ctx=child_ctx):
-                yield event
+        try:
+            for sub_agent in self.sub_agents:
+                if ctx.end_invocation:
+                    return
+                child_ctx = ctx.derive(agent_name=sub_agent.name)
+                async for event in sub_agent.astream(current_input, ctx=child_ctx):
+                    yield event
 
-                if event.is_final_response():
-                    current_input = event.text
+                    if event.is_final_response():
+                        current_input = event.text
+        except BaseException as exc:
+            await error_agent_span(_run_mgr, exc)
+            raise
+        else:
+            await end_agent_span(_run_mgr)

--- a/orxhestra/agents/sequential_agent.py
+++ b/orxhestra/agents/sequential_agent.py
@@ -12,7 +12,7 @@ from langchain_core.runnables import RunnableConfig
 
 from orxhestra.agents.base_agent import BaseAgent
 from orxhestra.agents.invocation_context import InvocationContext
-from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
+from orxhestra.agents.tracing import trace
 from orxhestra.events.event import Event
 
 
@@ -44,6 +44,7 @@ class SequentialAgent(BaseAgent):
         for agent in agents:
             self.register_sub_agent(agent)
 
+    @trace("SequentialAgent")
     async def astream(
         self,
         input: str,
@@ -68,33 +69,17 @@ class SequentialAgent(BaseAgent):
             All events from all sub-agents in order. Each sub-agent
             receives the previous agent's final answer text as input.
         """
-        ctx = self._ensure_ctx(config, ctx)
-        ctx, _run_mgr = await start_agent_span(
-            ctx, self.name, "SequentialAgent", {"input": input},
-        )
-
         if not self.sub_agents:
-            await end_agent_span(_run_mgr)
             return
 
         current_input = input
 
-        _span_err: BaseException | None = None
-        try:
-            for sub_agent in self.sub_agents:
-                if ctx.end_invocation:
-                    return
-                child_ctx = ctx.derive(agent_name=sub_agent.name)
-                async for event in sub_agent.astream(current_input, ctx=child_ctx):
-                    yield event
+        for sub_agent in self.sub_agents:
+            if ctx.end_invocation:
+                return
+            child_ctx = ctx.derive(agent_name=sub_agent.name)
+            async for event in sub_agent.astream(current_input, ctx=child_ctx):
+                yield event
 
-                    if event.is_final_response():
-                        current_input = event.text
-        except BaseException as exc:
-            _span_err = exc
-            raise
-        finally:
-            if _span_err is not None:
-                await error_agent_span(_run_mgr, _span_err)
-            else:
-                await end_agent_span(_run_mgr)
+                if event.is_final_response():
+                    current_input = event.text

--- a/orxhestra/agents/sequential_agent.py
+++ b/orxhestra/agents/sequential_agent.py
@@ -79,6 +79,7 @@ class SequentialAgent(BaseAgent):
 
         current_input = input
 
+        _span_err: BaseException | None = None
         try:
             for sub_agent in self.sub_agents:
                 if ctx.end_invocation:
@@ -90,7 +91,10 @@ class SequentialAgent(BaseAgent):
                     if event.is_final_response():
                         current_input = event.text
         except BaseException as exc:
-            await error_agent_span(_run_mgr, exc)
+            _span_err = exc
             raise
-        else:
-            await end_agent_span(_run_mgr)
+        finally:
+            if _span_err is not None:
+                await error_agent_span(_run_mgr, _span_err)
+            else:
+                await end_agent_span(_run_mgr)

--- a/orxhestra/agents/tracing.py
+++ b/orxhestra/agents/tracing.py
@@ -1,0 +1,135 @@
+"""Hierarchical tracing via LangChain's AsyncCallbackManager.
+
+Emits ``on_chain_start`` / ``on_chain_end`` spans so that any LangChain
+callback handler (Langfuse, LangSmith, custom) automatically builds a
+nested execution trace.  Zero overhead when no callbacks are configured.
+
+Usage in an agent's ``astream()``::
+
+    ctx, run_manager = await start_agent_span(
+        ctx, self.name, "LlmAgent", {"input": input}
+    )
+    try:
+        ...  # yield events
+    except BaseException as exc:
+        await error_agent_span(run_manager, exc)
+        raise
+    else:
+        await end_agent_span(run_manager)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.callbacks.manager import (
+    AsyncCallbackManager,
+    AsyncCallbackManagerForChainRun,
+)
+
+if TYPE_CHECKING:
+    from orxhestra.agents.invocation_context import InvocationContext
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+def _get_callbacks(
+    ctx: InvocationContext,
+) -> list[Any] | AsyncCallbackManager | None:
+    """Extract callbacks from ``run_config``, or ``None`` if absent."""
+    cbs = ctx.run_config.get("callbacks")
+    if cbs is None:
+        return None
+    if isinstance(cbs, list) and len(cbs) == 0:
+        return None
+    return cbs
+
+
+async def start_agent_span(
+    ctx: InvocationContext,
+    agent_name: str,
+    agent_type: str,
+    inputs: dict[str, Any],
+) -> tuple[InvocationContext, AsyncCallbackManagerForChainRun | None]:
+    """Open a trace span for an agent and return an updated context.
+
+    If no callbacks are configured the original *ctx* is returned
+    unchanged alongside ``None`` — zero allocation, zero overhead.
+
+    The returned context has ``run_config["callbacks"]`` replaced with
+    a **child** ``AsyncCallbackManager`` whose ``parent_run_id`` points
+    to the newly opened span.  Any nested operation (sub-agent, LLM
+    call, tool invocation) that uses this child manager will appear as
+    a child span in the trace.
+
+    Parameters
+    ----------
+    ctx:
+        Current invocation context.
+    agent_name:
+        Human-readable name shown in the trace (e.g. ``"Researcher"``).
+    agent_type:
+        Agent class name (e.g. ``"LlmAgent"``, ``"SequentialAgent"``).
+    inputs:
+        Serialisable dict passed to ``on_chain_start`` as the inputs.
+
+    Returns
+    -------
+    tuple[InvocationContext, AsyncCallbackManagerForChainRun | None]
+        Updated context and the run manager (call ``end_agent_span`` /
+        ``error_agent_span`` when the agent finishes).
+    """
+    callbacks = _get_callbacks(ctx)
+    if callbacks is None:
+        return ctx, None
+
+    manager: AsyncCallbackManager = AsyncCallbackManager.configure(
+        inheritable_callbacks=callbacks,
+        inheritable_metadata=ctx.run_config.get("metadata"),
+        inheritable_tags=ctx.run_config.get("tags"),
+    )
+
+    serialized: dict[str, Any] = {
+        "name": agent_name,
+        "id": [agent_type, agent_name],
+    }
+
+    run_manager: AsyncCallbackManagerForChainRun = await manager.on_chain_start(
+        serialized, inputs,
+    )
+
+    child_manager: AsyncCallbackManager = run_manager.get_child(tag=agent_name)
+
+    new_config: dict[str, Any] = {
+        **ctx.run_config,
+        "callbacks": child_manager,
+    }
+    new_ctx: InvocationContext = ctx.model_copy(
+        update={"run_config": new_config},
+    )
+    return new_ctx, run_manager
+
+
+async def end_agent_span(
+    run_manager: AsyncCallbackManagerForChainRun | None,
+    outputs: dict[str, Any] | None = None,
+) -> None:
+    """Close a previously opened agent span.
+
+    Safe to call with ``None`` (no-op when tracing is disabled).
+    """
+    if run_manager is not None:
+        await run_manager.on_chain_end(outputs or {})
+
+
+async def error_agent_span(
+    run_manager: AsyncCallbackManagerForChainRun | None,
+    error: BaseException,
+) -> None:
+    """Record an error and close a previously opened agent span.
+
+    Safe to call with ``None`` (no-op when tracing is disabled).
+    """
+    if run_manager is not None:
+        await run_manager.on_chain_error(error)

--- a/orxhestra/agents/tracing.py
+++ b/orxhestra/agents/tracing.py
@@ -4,23 +4,33 @@ Emits ``on_chain_start`` / ``on_chain_end`` spans so that any LangChain
 callback handler (Langfuse, LangSmith, custom) automatically builds a
 nested execution trace.  Zero overhead when no callbacks are configured.
 
-Usage in an agent's ``astream()``::
+Usage — decorator (preferred)::
 
-    ctx, run_manager = await start_agent_span(
-        ctx, self.name, "LlmAgent", {"input": input}
-    )
+    @traced("LlmAgent")
+    async def astream(self, input, config=None, *, ctx=None):
+        ...  # yield events normally, no tracing code needed
+
+Usage — manual (for non-BaseAgent callers like Runner)::
+
+    ctx, run_mgr = await start_agent_span(ctx, name, "Runner", {"input": msg})
+    _span_err = None
     try:
-        ...  # yield events
+        ...
     except BaseException as exc:
-        await error_agent_span(run_manager, exc)
+        _span_err = exc
         raise
-    else:
-        await end_agent_span(run_manager)
+    finally:
+        if _span_err:
+            await error_agent_span(run_mgr, _span_err)
+        else:
+            await end_agent_span(run_mgr)
 """
 
 from __future__ import annotations
 
+import functools
 import logging
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.callbacks.manager import (
@@ -30,6 +40,7 @@ from langchain_core.callbacks.manager import (
 
 if TYPE_CHECKING:
     from orxhestra.agents.invocation_context import InvocationContext
+    from orxhestra.events.event import Event
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -65,14 +76,14 @@ async def start_agent_span(
 
     Parameters
     ----------
-    ctx:
+    ctx :
         Current invocation context.
-    agent_name:
+    agent_name :
         Human-readable name shown in the trace (e.g. ``"Researcher"``).
-    agent_type:
+    agent_type :
         Agent class name (e.g. ``"LlmAgent"``, ``"SequentialAgent"``).
-    inputs:
-        Serialisable dict passed to ``on_chain_start`` as the inputs.
+    inputs :
+        Serializable dict passed to ``on_chain_start`` as the inputs.
 
     Returns
     -------
@@ -133,3 +144,52 @@ async def error_agent_span(
     """
     if run_manager is not None:
         await run_manager.on_chain_error(error)
+
+
+def trace(agent_type: str):
+    """Decorator that wraps an agent's ``astream()`` with a trace span.
+
+    Handles ``_ensure_ctx``, ``start_agent_span``, ``end_agent_span``,
+    and ``error_agent_span`` automatically.  The decorated method
+    receives a fully prepared ``ctx`` — it must **not** call
+    ``_ensure_ctx()`` itself.
+
+    Usage::
+
+        @trace("LlmAgent")
+        async def astream(self, input, config=None, *, ctx=None):
+            # ctx is already set up — just yield events
+            yield self._emit_event(ctx, ...)
+    """
+
+    def decorator(
+        fn: Any,
+    ) -> Any:
+        @functools.wraps(fn)
+        async def wrapper(
+            self: Any,
+            input: str,
+            config: Any = None,
+            *,
+            ctx: Any = None,
+        ) -> AsyncIterator[Event]:
+            ctx = self._ensure_ctx(config, ctx)
+            ctx, run_mgr = await start_agent_span(
+                ctx, self.name, agent_type, {"input": input},
+            )
+            err: BaseException | None = None
+            try:
+                async for event in fn(self, input, config, ctx=ctx):
+                    yield event
+            except BaseException as exc:
+                err = exc
+                raise
+            finally:
+                if err is not None:
+                    await error_agent_span(run_mgr, err)
+                else:
+                    await end_agent_span(run_mgr)
+
+        return wrapper
+
+    return decorator

--- a/orxhestra/agents/tracing.py
+++ b/orxhestra/agents/tracing.py
@@ -6,7 +6,7 @@ nested execution trace.  Zero overhead when no callbacks are configured.
 
 Usage — decorator (preferred)::
 
-    @traced("LlmAgent")
+    @trace("LlmAgent")
     async def astream(self, input, config=None, *, ctx=None):
         ...  # yield events normally, no tracing code needed
 
@@ -177,10 +177,16 @@ def trace(agent_type: str):
             ctx, run_mgr = await start_agent_span(
                 ctx, self.name, agent_type, {"input": input},
             )
+            last_text: str = ""
             err: BaseException | None = None
             try:
                 async for event in fn(self, input, config, ctx=ctx):
+                    if hasattr(event, "text") and event.text:
+                        last_text = event.text
                     yield event
+            except GeneratorExit:
+                # Parent stopped consuming — normal cleanup, not an error.
+                pass
             except BaseException as exc:
                 err = exc
                 raise
@@ -188,7 +194,9 @@ def trace(agent_type: str):
                 if err is not None:
                     await error_agent_span(run_mgr, err)
                 else:
-                    await end_agent_span(run_mgr)
+                    await end_agent_span(
+                        run_mgr, {"output": last_text} if last_text else None,
+                    )
 
         return wrapper
 

--- a/orxhestra/auth/__init__.py
+++ b/orxhestra/auth/__init__.py
@@ -1,0 +1,79 @@
+"""Authentication, cryptography, and security utilities.
+
+SSRF protection is always available (stdlib only).  Ed25519 crypto and
+JWT parsing require optional dependencies::
+
+    pip install orxhestra[auth]
+"""
+
+from orxhestra.auth.ssrf import (
+    validate_and_pin_url,
+    validate_redirect_target,
+    validate_url_host,
+)
+
+# Symbols that require optional deps are lazy-loaded below.
+_CRYPTO_SYMBOLS: dict[str, tuple[str, str]] = {
+    "generate_ed25519_keypair": ("orxhestra.auth.crypto", "generate_ed25519_keypair"),
+    "serialize_private_key": ("orxhestra.auth.crypto", "serialize_private_key"),
+    "deserialize_private_key": ("orxhestra.auth.crypto", "deserialize_private_key"),
+    "serialize_public_key": ("orxhestra.auth.crypto", "serialize_public_key"),
+    "deserialize_public_key": ("orxhestra.auth.crypto", "deserialize_public_key"),
+    "sign_message": ("orxhestra.auth.crypto", "sign_message"),
+    "verify_signature": ("orxhestra.auth.crypto", "verify_signature"),
+    "public_key_to_did_key": ("orxhestra.auth.crypto", "public_key_to_did_key"),
+    "did_key_to_public_key": ("orxhestra.auth.crypto", "did_key_to_public_key"),
+    "did_key_fragment": ("orxhestra.auth.crypto", "did_key_fragment"),
+    "load_or_create_signing_key": ("orxhestra.auth.crypto", "load_or_create_signing_key"),
+    "canonicalize_json": ("orxhestra.auth.crypto", "canonicalize_json"),
+    "sign_json_payload": ("orxhestra.auth.crypto", "sign_json_payload"),
+    "verify_json_signature": ("orxhestra.auth.crypto", "verify_json_signature"),
+    "ED25519_MULTICODEC_PREFIX": ("orxhestra.auth.crypto", "ED25519_MULTICODEC_PREFIX"),
+    "TokenType": ("orxhestra.auth.token_parser", "TokenType"),
+    "detect_token_type": ("orxhestra.auth.token_parser", "detect_token_type"),
+    "parse_jwt_claims": ("orxhestra.auth.token_parser", "parse_jwt_claims"),
+    "extract_identity_from_token": (
+        "orxhestra.auth.token_parser",
+        "extract_identity_from_token",
+    ),
+}
+
+
+def __getattr__(name: str):
+    """Lazy-load crypto and token_parser symbols to avoid hard dependency."""
+    if name in _CRYPTO_SYMBOLS:
+        module_path, attr = _CRYPTO_SYMBOLS[name]
+        import importlib
+
+        module = importlib.import_module(module_path)
+        return getattr(module, attr)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = [
+    # ssrf (always available)
+    "validate_url_host",
+    "validate_and_pin_url",
+    "validate_redirect_target",
+    # crypto (requires orxhestra[auth])
+    "generate_ed25519_keypair",
+    "serialize_private_key",
+    "deserialize_private_key",
+    "serialize_public_key",
+    "deserialize_public_key",
+    "sign_message",
+    "verify_signature",
+    "public_key_to_did_key",
+    "did_key_to_public_key",
+    "did_key_fragment",
+    "load_or_create_signing_key",
+    "canonicalize_json",
+    "sign_json_payload",
+    "verify_json_signature",
+    "ED25519_MULTICODEC_PREFIX",
+    # token_parser (requires orxhestra[auth])
+    "TokenType",
+    "detect_token_type",
+    "parse_jwt_claims",
+    "extract_identity_from_token",
+]

--- a/orxhestra/auth/crypto.py
+++ b/orxhestra/auth/crypto.py
@@ -1,0 +1,474 @@
+"""Ed25519 cryptographic operations for orxhestra.
+
+Handles key generation, serialisation, signing, verification, and
+``did:key`` creation.  Also provides RFC 8785 JSON canonicalisation
+for deterministic payload signing.
+
+Requires the ``cryptography`` and ``base58`` packages.  Install via::
+
+    pip install orxhestra[auth]
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import unicodedata
+from pathlib import Path
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+try:
+    import base58
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        PublicFormat,
+    )
+
+    _HAS_CRYPTO_DEPS: bool = True
+except ImportError:  # pragma: no cover
+    _HAS_CRYPTO_DEPS = False
+
+# Multicodec prefix for Ed25519 public key (0xed 0x01).
+ED25519_MULTICODEC_PREFIX: bytes = bytes([0xED, 0x01])
+
+
+def _check_crypto_deps() -> None:
+    """Raise ``ImportError`` if crypto dependencies are missing."""
+    if not _HAS_CRYPTO_DEPS:
+        raise ImportError(
+            "cryptography and base58 are required for Ed25519 operations. "
+            "Install them with: pip install orxhestra[auth]"
+        )
+
+
+# ── Key generation & serialisation ──────────────────────────────
+
+
+def generate_ed25519_keypair() -> tuple[Ed25519PrivateKey, Ed25519PublicKey]:
+    """Generate a new Ed25519 keypair.
+
+    Returns
+    -------
+    tuple[Ed25519PrivateKey, Ed25519PublicKey]
+        The generated private and public keys.
+
+    Raises
+    ------
+    ImportError
+        If ``cryptography`` is not installed.
+    """
+    _check_crypto_deps()
+    private_key: Ed25519PrivateKey = Ed25519PrivateKey.generate()
+    return private_key, private_key.public_key()
+
+
+def serialize_private_key(private_key: Ed25519PrivateKey) -> bytes:
+    """Serialise a private key to its raw 32-byte seed.
+
+    Parameters
+    ----------
+    private_key : Ed25519PrivateKey
+        The private key to serialise.
+
+    Returns
+    -------
+    bytes
+        Raw 32-byte seed.
+    """
+    return private_key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+
+
+def deserialize_private_key(key_bytes: bytes) -> Ed25519PrivateKey:
+    """Deserialise a private key from a raw 32-byte seed.
+
+    Parameters
+    ----------
+    key_bytes : bytes
+        Raw 32-byte seed.
+
+    Returns
+    -------
+    Ed25519PrivateKey
+    """
+    _check_crypto_deps()
+    return Ed25519PrivateKey.from_private_bytes(key_bytes)
+
+
+def serialize_public_key(public_key: Ed25519PublicKey) -> bytes:
+    """Serialise a public key to raw 32 bytes.
+
+    Parameters
+    ----------
+    public_key : Ed25519PublicKey
+        The public key to serialise.
+
+    Returns
+    -------
+    bytes
+        Raw 32-byte public key.
+    """
+    return public_key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def deserialize_public_key(key_bytes: bytes) -> Ed25519PublicKey:
+    """Deserialise a public key from raw 32 bytes.
+
+    Parameters
+    ----------
+    key_bytes : bytes
+        Raw 32-byte public key.
+
+    Returns
+    -------
+    Ed25519PublicKey
+    """
+    _check_crypto_deps()
+    return Ed25519PublicKey.from_public_bytes(key_bytes)
+
+
+# ── Signing & verification ──────────────────────────────────────
+
+
+def sign_message(private_key: Ed25519PrivateKey, message: bytes) -> bytes:
+    """Sign a message with an Ed25519 private key.
+
+    Parameters
+    ----------
+    private_key : Ed25519PrivateKey
+        The signing key.
+    message : bytes
+        The message to sign.
+
+    Returns
+    -------
+    bytes
+        The 64-byte Ed25519 signature.
+    """
+    return private_key.sign(message)
+
+
+def verify_signature(
+    public_key: Ed25519PublicKey, signature: bytes, message: bytes,
+) -> bool:
+    """Verify an Ed25519 signature.
+
+    Parameters
+    ----------
+    public_key : Ed25519PublicKey
+        The verification key.
+    signature : bytes
+        The 64-byte signature to verify.
+    message : bytes
+        The original message.
+
+    Returns
+    -------
+    bool
+        ``True`` if the signature is valid.
+    """
+    try:
+        public_key.verify(signature, message)
+        return True
+    except Exception:
+        return False
+
+
+# ── DID:key encoding ────────────────────────────────────────────
+
+
+def public_key_to_did_key(public_key: Ed25519PublicKey) -> str:
+    """Convert an Ed25519 public key to a ``did:key`` identifier.
+
+    Format: ``did:key:z<base58btc(multicodec_prefix + raw_public_key)>``
+
+    Parameters
+    ----------
+    public_key : Ed25519PublicKey
+        The public key to encode.
+
+    Returns
+    -------
+    str
+        The ``did:key`` identifier string.
+    """
+    raw_bytes: bytes = serialize_public_key(public_key)
+    multicodec_bytes: bytes = ED25519_MULTICODEC_PREFIX + raw_bytes
+    encoded: str = base58.b58encode(multicodec_bytes).decode("ascii")
+    return f"did:key:z{encoded}"
+
+
+def did_key_to_public_key(did: str) -> Ed25519PublicKey:
+    """Extract an Ed25519 public key from a ``did:key`` identifier.
+
+    Parameters
+    ----------
+    did : str
+        A ``did:key:z...`` identifier string.
+
+    Returns
+    -------
+    Ed25519PublicKey
+        The decoded public key.
+
+    Raises
+    ------
+    ValueError
+        If the DID format is invalid or uses a non-Ed25519 multicodec.
+    """
+    _check_crypto_deps()
+    if not did.startswith("did:key:z"):
+        raise ValueError(f"Invalid did:key format: {did}")
+
+    encoded: str = did[len("did:key:z"):]
+    decoded: bytes = base58.b58decode(encoded)
+
+    if decoded[:2] != ED25519_MULTICODEC_PREFIX:
+        raise ValueError("Not an Ed25519 did:key (wrong multicodec prefix)")
+
+    return deserialize_public_key(decoded[2:])
+
+
+def did_key_fragment(did: str) -> str:
+    """Return the ``did:key`` verification method fragment.
+
+    Per the did:key spec, the fragment is the multibase-encoded public
+    key portion (the ``z...`` part after ``did:key:``).
+
+    Parameters
+    ----------
+    did : str
+        A ``did:key:z...`` identifier string.
+
+    Returns
+    -------
+    str
+        The fragment, e.g. ``#z6Mk...``.
+
+    Raises
+    ------
+    ValueError
+        If the DID format is invalid.
+    """
+    if not did.startswith("did:key:z"):
+        raise ValueError(f"Invalid did:key format: {did}")
+    multibase: str = did[len("did:key:"):]
+    return f"#{multibase}"
+
+
+# ── Signing key persistence ─────────────────────────────────────
+
+
+def load_or_create_signing_key(
+    key_file: str | Path,
+    *,
+    encryption_password: str | None = None,
+) -> tuple[Ed25519PrivateKey, str]:
+    """Load a signing key from file or create a new one.
+
+    When *encryption_password* is provided, the private key is stored
+    encrypted using Fernet (PBKDF2-SHA256 derived key).  Otherwise
+    falls back to base64 plaintext.
+
+    Parameters
+    ----------
+    key_file : str or Path
+        Path to the JSON key file.
+    encryption_password : str, optional
+        Password for Fernet-encrypting the key at rest.
+
+    Returns
+    -------
+    tuple[Ed25519PrivateKey, str]
+        The private key and its ``did:key`` identifier.
+    """
+    _check_crypto_deps()
+    key_path = Path(key_file)
+    fernet_key: bytes | None = _derive_fernet_key(encryption_password)
+
+    if key_path.exists():
+        try:
+            data: dict[str, Any] = json.loads(key_path.read_text())
+
+            if "private_key_encrypted" in data and fernet_key:
+                from cryptography.fernet import Fernet
+
+                cipher = Fernet(fernet_key)
+                priv_bytes: bytes = cipher.decrypt(
+                    data["private_key_encrypted"].encode("utf-8")
+                )
+            else:
+                priv_bytes = base64.b64decode(data["private_key_b64"])
+
+            private_key: Ed25519PrivateKey = deserialize_private_key(priv_bytes)
+            did: str = data["did_key"]
+            return private_key, did
+        except Exception:
+            logger.warning(
+                "Corrupted signing key file %s — generating new key.", key_path,
+            )
+
+    # Generate new keypair.
+    private_key, public_key = generate_ed25519_keypair()
+    did = public_key_to_did_key(public_key)
+
+    raw_bytes: bytes = serialize_private_key(private_key)
+    key_data: dict[str, Any] = {
+        "did_key": did,
+        "algorithm": "Ed25519",
+    }
+
+    if fernet_key:
+        from cryptography.fernet import Fernet
+
+        cipher = Fernet(fernet_key)
+        key_data["private_key_encrypted"] = cipher.encrypt(raw_bytes).decode("utf-8")
+        key_data["encryption"] = "fernet-pbkdf2-sha256"
+    else:
+        key_data["private_key_b64"] = base64.b64encode(raw_bytes).decode("ascii")
+
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_text(json.dumps(key_data, indent=2))
+    return private_key, did
+
+
+def _derive_fernet_key(password: str | None) -> bytes | None:
+    """Derive a Fernet encryption key from a password.
+
+    Parameters
+    ----------
+    password : str or None
+        The password.  Returns ``None`` when no password is provided.
+
+    Returns
+    -------
+    bytes or None
+        The derived Fernet key, or ``None``.
+    """
+    if not password:
+        return None
+    try:
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+        salt: bytes = b"orxhestra-signing-key-v1"
+        kdf = PBKDF2HMAC(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=salt,
+            iterations=480_000,
+        )
+        return base64.urlsafe_b64encode(kdf.derive(password.encode("utf-8")))
+    except ImportError:
+        return None
+
+
+# ── JSON canonicalisation (RFC 8785 subset) ─────────────────────
+
+
+def _normalize_for_signing(obj: Any) -> Any:
+    """Recursively normalise values for deterministic JSON serialisation.
+
+    Applies NFC Unicode normalisation for strings and ensures consistent
+    number representation.
+    """
+    if isinstance(obj, str):
+        return unicodedata.normalize("NFC", obj)
+    if isinstance(obj, bool):
+        return obj
+    if isinstance(obj, int):
+        return obj
+    if isinstance(obj, float):
+        if obj == int(obj) and not (obj == 0.0 and str(obj).startswith("-")):
+            return int(obj)
+        return obj
+    if isinstance(obj, dict):
+        return {
+            _normalize_for_signing(k): _normalize_for_signing(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_normalize_for_signing(x) for x in obj]
+    return obj
+
+
+def canonicalize_json(payload: dict[str, Any]) -> bytes:
+    """Produce a canonical JSON byte string following RFC 8785 (JCS).
+
+    Uses sorted keys, compact separators, NFC normalisation, and
+    UTF-8 encoding.
+
+    Parameters
+    ----------
+    payload : dict[str, Any]
+        The JSON-serialisable payload.
+
+    Returns
+    -------
+    bytes
+        The canonical UTF-8 encoded JSON.
+    """
+    normalised: Any = _normalize_for_signing(payload)
+    canonical: str = json.dumps(
+        normalised, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+    )
+    return canonical.encode("utf-8")
+
+
+def sign_json_payload(
+    private_key: Ed25519PrivateKey, payload: dict[str, Any],
+) -> str:
+    """Sign a JSON payload and return a base64url signature.
+
+    The payload is first canonicalised using :func:`canonicalize_json`
+    before signing.
+
+    Parameters
+    ----------
+    private_key : Ed25519PrivateKey
+        The signing key.
+    payload : dict[str, Any]
+        The JSON payload to sign.
+
+    Returns
+    -------
+    str
+        Base64url-encoded signature string.
+    """
+    canonical_bytes: bytes = canonicalize_json(payload)
+    sig_bytes: bytes = sign_message(private_key, canonical_bytes)
+    return base64.urlsafe_b64encode(sig_bytes).decode("ascii")
+
+
+def verify_json_signature(
+    public_key: Ed25519PublicKey,
+    payload: dict[str, Any],
+    signature_b64: str,
+) -> bool:
+    """Verify a JSON payload signature.
+
+    Parameters
+    ----------
+    public_key : Ed25519PublicKey
+        The verification key.
+    payload : dict[str, Any]
+        The JSON payload that was signed.
+    signature_b64 : str
+        The base64url-encoded signature to verify.
+
+    Returns
+    -------
+    bool
+        ``True`` if the signature is valid.
+    """
+    canonical_bytes: bytes = canonicalize_json(payload)
+    sig_bytes: bytes = base64.urlsafe_b64decode(signature_b64)
+    return verify_signature(public_key, sig_bytes, canonical_bytes)

--- a/orxhestra/auth/ssrf.py
+++ b/orxhestra/auth/ssrf.py
@@ -1,0 +1,202 @@
+"""SSRF protection utilities for orxhestra.
+
+Validates hostnames and resolved IPs against private/reserved ranges
+before making outbound HTTP requests.  Returns pinned IPs to prevent
+DNS rebinding (TOCTOU) attacks.
+
+All functions are pure-stdlib and have no external dependencies.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from urllib.parse import urlparse
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+# Domains that are always blocked (case-insensitive).
+_BLOCKED_DOMAINS: set[str] = {
+    "localhost",
+    "localhost.localdomain",
+    "metadata.google.internal",
+    "metadata.google.com",
+    "169.254.169.254",
+}
+
+# Domain suffixes that are always blocked.
+_BLOCKED_SUFFIXES: tuple[str, ...] = (
+    ".local",
+    ".internal",
+    ".localhost",
+)
+
+# Maximum redirects to follow (0 = no redirects).
+MAX_REDIRECTS: int = 0
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    """Check whether an IP address is private, loopback, link-local, or reserved.
+
+    Parameters
+    ----------
+    ip_str : str
+        The IP address string to check.
+
+    Returns
+    -------
+    bool
+        ``True`` if the address is in a non-public range.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved
+    except ValueError:
+        return False
+
+
+def validate_url_host(hostname: str) -> str | None:
+    """Validate that a hostname is safe for outbound requests.
+
+    Blocks private IPs, reserved ranges, localhost variants, cloud
+    metadata endpoints, and hostnames that resolve to private IPs.
+
+    Parameters
+    ----------
+    hostname : str
+        The hostname to validate.
+
+    Returns
+    -------
+    str or None
+        ``None`` if the hostname is safe, or an error string
+        describing why it was blocked.
+    """
+    if not hostname:
+        return "Empty hostname"
+
+    clean: str = hostname.lower().strip("[]")
+
+    if clean in _BLOCKED_DOMAINS:
+        return f"Blocked: private hostname '{hostname}'"
+
+    for suffix in _BLOCKED_SUFFIXES:
+        if clean.endswith(suffix):
+            return f"Blocked: private domain suffix '{hostname}'"
+
+    # Try to parse as a raw IP address.
+    try:
+        ip = ipaddress.ip_address(clean)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+            return f"Blocked: private/reserved IP address '{hostname}'"
+    except ValueError:
+        pass  # Not a raw IP — continue to DNS resolution.
+
+    # Resolve hostname and check ALL resolved IPs.
+    try:
+        resolved = socket.getaddrinfo(clean, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        for _family, _, _, _, addr in resolved:
+            ip_str: str = addr[0]
+            if _is_private_ip(ip_str):
+                return f"Blocked: '{hostname}' resolves to private IP {ip_str}"
+    except socket.gaierror:
+        pass  # DNS resolution failed — let the HTTP client handle it.
+
+    return None
+
+
+def validate_and_pin_url(url: str) -> tuple[str | None, list[str]]:
+    """Validate a URL and return pinned resolved IPs.
+
+    Resolves DNS once during validation and returns the IPs so the
+    caller can connect directly to them, preventing DNS rebinding
+    (TOCTOU) attacks.
+
+    Parameters
+    ----------
+    url : str
+        The full URL to validate.
+
+    Returns
+    -------
+    tuple[str | None, list[str]]
+        A two-element tuple of ``(error_or_none, pinned_ips)``.
+        *error_or_none* is ``None`` when safe, or a descriptive
+        error string when blocked.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return ("Invalid URL", [])
+
+    hostname: str | None = parsed.hostname
+    if not hostname:
+        return ("No hostname in URL", [])
+
+    clean: str = hostname.lower().strip("[]")
+
+    if clean in _BLOCKED_DOMAINS:
+        return (f"Blocked: private hostname '{hostname}'", [])
+
+    for suffix in _BLOCKED_SUFFIXES:
+        if clean.endswith(suffix):
+            return (f"Blocked: private domain suffix '{hostname}'", [])
+
+    # Try to parse as a raw IP address.
+    try:
+        ip = ipaddress.ip_address(clean)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+            return (f"Blocked: private/reserved IP address '{hostname}'", [])
+        return (None, [str(ip)])
+    except ValueError:
+        pass  # Not a raw IP — resolve via DNS.
+
+    # Resolve hostname and pin all safe IPs.
+    safe_ips: list[str] = []
+    try:
+        resolved = socket.getaddrinfo(clean, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        for _family, _, _, _, addr in resolved:
+            ip_str: str = addr[0]
+            if _is_private_ip(ip_str):
+                return (f"Blocked: '{hostname}' resolves to private IP {ip_str}", [])
+            if ip_str not in safe_ips:
+                safe_ips.append(ip_str)
+    except socket.gaierror:
+        pass  # DNS resolution failed — let the HTTP client handle it.
+
+    return (None, safe_ips)
+
+
+def validate_redirect_target(redirect_url: str, original_hostname: str) -> str | None:
+    """Validate a redirect target URL.
+
+    Blocks redirects to private IPs or otherwise unsafe hosts.
+
+    Parameters
+    ----------
+    redirect_url : str
+        The redirect destination URL.
+    original_hostname : str
+        The hostname of the original request (currently unused but
+        reserved for future same-origin checks).
+
+    Returns
+    -------
+    str or None
+        ``None`` if safe, or an error string if blocked.
+    """
+    try:
+        parsed = urlparse(redirect_url)
+    except Exception:
+        return "Invalid redirect URL"
+
+    redirect_host: str | None = parsed.hostname
+    if not redirect_host:
+        return "No hostname in redirect URL"
+
+    error: str | None = validate_url_host(redirect_host)
+    if error:
+        return f"Redirect blocked: {error}"
+
+    return None

--- a/orxhestra/auth/token_parser.py
+++ b/orxhestra/auth/token_parser.py
@@ -1,0 +1,204 @@
+"""Token type detection and JWT parsing.
+
+Identifies whether an input string is a JWT, DID, URL, API key, or
+unknown, and extracts claims from JWTs without signature verification
+(useful for identity bridging and token classification).
+
+Requires the ``PyJWT`` package for JWT decoding.  Install via::
+
+    pip install orxhestra[auth]
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from enum import Enum
+from typing import Any
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+try:
+    import jwt
+
+    _HAS_PYJWT: bool = True
+except ImportError:  # pragma: no cover
+    _HAS_PYJWT = False
+
+
+def _check_jwt_deps() -> None:
+    """Raise ``ImportError`` if PyJWT is not installed."""
+    if not _HAS_PYJWT:
+        raise ImportError(
+            "PyJWT is required for JWT parsing. "
+            "Install it with: pip install orxhestra[auth]"
+        )
+
+
+class TokenType(str, Enum):
+    """Classification of an identity token string.
+
+    Attributes
+    ----------
+    JWT : str
+        JSON Web Token (three base64url segments).
+    DID : str
+        Decentralized Identifier (``did:<method>:<id>``).
+    URL : str
+        HTTP(S) URL (e.g. an A2A Agent Card endpoint).
+    API_KEY : str
+        Opaque API key (hex or mixed-case alphanumeric, >= 32 chars).
+    UNKNOWN : str
+        Unrecognised token format.
+    """
+
+    JWT = "jwt"
+    DID = "did"
+    URL = "url"
+    API_KEY = "api_key"
+    UNKNOWN = "unknown"
+
+
+# Regex patterns for token type detection.
+DID_PATTERN: re.Pattern[str] = re.compile(r"^did:[a-z0-9]+:.+$", re.IGNORECASE)
+URL_PATTERN: re.Pattern[str] = re.compile(r"^https?://.+$", re.IGNORECASE)
+JWT_PATTERN: re.Pattern[str] = re.compile(
+    r"^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$"
+)
+API_KEY_PATTERN: re.Pattern[str] = re.compile(
+    r"^[A-Fa-f0-9]{32,}$|^(?=.*[A-Z])(?=.*[a-z0-9])[A-Za-z0-9_-]{32,}$"
+)
+
+
+def detect_token_type(token: str) -> TokenType:
+    """Detect the type of an identity token string.
+
+    Uses regex matching and, for JWT candidates, attempts a decode
+    (without signature verification) to confirm validity.
+
+    Parameters
+    ----------
+    token : str
+        The raw token string.
+
+    Returns
+    -------
+    TokenType
+        The detected token type.
+    """
+    token = token.strip()
+
+    if DID_PATTERN.match(token):
+        return TokenType.DID
+
+    if JWT_PATTERN.match(token) and _HAS_PYJWT:
+        try:
+            jwt.decode(token, options={"verify_signature": False})
+            return TokenType.JWT
+        except Exception:
+            pass
+
+    if URL_PATTERN.match(token):
+        return TokenType.URL
+
+    if API_KEY_PATTERN.match(token) and not DID_PATTERN.match(token):
+        return TokenType.API_KEY
+
+    return TokenType.UNKNOWN
+
+
+def parse_jwt_claims(token: str) -> dict[str, Any] | None:
+    """Parse a JWT without verification and extract claims.
+
+    Parameters
+    ----------
+    token : str
+        The raw JWT string.
+
+    Returns
+    -------
+    dict[str, Any] or None
+        A dictionary with ``header``, ``claims``, ``subject``,
+        ``issuer``, ``audience``, ``expiry``, ``issued_at``, and
+        ``scopes`` keys, or ``None`` if the token cannot be decoded.
+
+    Raises
+    ------
+    ImportError
+        If ``PyJWT`` is not installed.
+    """
+    _check_jwt_deps()
+    try:
+        claims: dict[str, Any] = jwt.decode(
+            token,
+            options={
+                "verify_signature": False,
+                "verify_exp": False,
+                "verify_aud": False,
+            },
+        )
+        header: dict[str, Any] = jwt.get_unverified_header(token)
+        return {
+            "header": header,
+            "claims": claims,
+            "subject": claims.get("sub"),
+            "issuer": claims.get("iss"),
+            "audience": claims.get("aud"),
+            "expiry": claims.get("exp"),
+            "issued_at": claims.get("iat"),
+            "scopes": claims.get("scope", "").split() if claims.get("scope") else [],
+        }
+    except Exception:
+        logger.warning("Failed to parse JWT token.")
+        return None
+
+
+def extract_identity_from_token(token: str) -> dict[str, Any]:
+    """Extract identity information from any supported token type.
+
+    Detects the token type and extracts the relevant fields.  For
+    JWTs this includes subject, issuer, scopes, and expiry.  For DIDs
+    it extracts the method and specific identifier.
+
+    Parameters
+    ----------
+    token : str
+        The raw token string.
+
+    Returns
+    -------
+    dict[str, Any]
+        A dictionary with ``token_type``, ``original_token``, and
+        type-specific fields.
+    """
+    token_type: TokenType = detect_token_type(token)
+    result: dict[str, Any] = {
+        "token_type": token_type.value,
+        "original_token": token,
+    }
+
+    if token_type == TokenType.JWT:
+        parsed: dict[str, Any] | None = parse_jwt_claims(token)
+        if parsed:
+            result["subject"] = parsed["subject"]
+            result["issuer"] = parsed["issuer"]
+            result["scopes"] = parsed["scopes"]
+            result["expiry"] = parsed["expiry"]
+            result["jwt_header"] = parsed["header"]
+
+    elif token_type == TokenType.DID:
+        parts: list[str] = token.split(":")
+        result["did_method"] = parts[1] if len(parts) >= 3 else "unknown"
+        result["did_specific_id"] = ":".join(parts[2:]) if len(parts) >= 3 else token
+
+    elif token_type == TokenType.URL:
+        result["url"] = token
+        result["note"] = "URL-based identity (e.g., A2A Agent Card endpoint)"
+
+    elif token_type == TokenType.API_KEY:
+        result["key_preview"] = (
+            token[:6] + "..." + token[-4:] if len(token) > 12 else "***"
+        )
+        result["key_length"] = len(token)
+
+    return result

--- a/orxhestra/runner.py
+++ b/orxhestra/runner.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING
 from langchain_core.runnables import RunnableConfig
 
 from orxhestra.agents.invocation_context import InvocationContext
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
 from orxhestra.artifacts.base_artifact_service import BaseArtifactService
 from orxhestra.events.event import Event, EventType
 from orxhestra.models.part import Content
@@ -194,27 +195,37 @@ class Runner:
         )
         await self.session_service.append_event(session, user_event)
 
+        ctx, run_manager = await start_agent_span(
+            ctx, f"Runner:{self.agent.name}", "Runner", {"input": new_message},
+        )
+
         current_agent = self.agent
 
-        while True:
-            transfer_target: str | None = None
+        try:
+            while True:
+                transfer_target: str | None = None
 
-            async for event in current_agent.astream(new_message, ctx=ctx):
-                await self.session_service.append_event(session, event)
-                yield event
+                async for event in current_agent.astream(new_message, ctx=ctx):
+                    await self.session_service.append_event(session, event)
+                    yield event
 
-                if event.actions and event.actions.transfer_to_agent:
-                    transfer_target = event.actions.transfer_to_agent
+                    if event.actions and event.actions.transfer_to_agent:
+                        transfer_target = event.actions.transfer_to_agent
 
-            if transfer_target is None:
-                break
+                if transfer_target is None:
+                    break
 
-            target = self.agent.find_agent(transfer_target)
-            if target is None:
-                break
+                target = self.agent.find_agent(transfer_target)
+                if target is None:
+                    break
 
-            current_agent = target
-            ctx = ctx.model_copy(update={"agent_name": target.name})
+                current_agent = target
+                ctx = ctx.model_copy(update={"agent_name": target.name})
+        except BaseException as exc:
+            await error_agent_span(run_manager, exc)
+            raise
+        else:
+            await end_agent_span(run_manager)
 
         # Run compaction after all events are yielded from the agent.
         # Only compact at the end of an invocation, never mid-stream.

--- a/orxhestra/runner.py
+++ b/orxhestra/runner.py
@@ -166,6 +166,9 @@ class Runner:
 
         run_config = {**self._base_config, **(config or {})}
 
+        # Default trace/run name for observability backends (Langfuse, etc.)
+        run_config.setdefault("run_name", self.app_name or self.agent.name)
+
         # Expose session metadata so callbacks (tracing, etc.) can use it
         meta = dict(run_config.get("metadata", {}))
         meta.setdefault("session_id", session.id)
@@ -200,6 +203,7 @@ class Runner:
         )
 
         current_agent = self.agent
+        last_text: str = ""
 
         _span_err: BaseException | None = None
         try:
@@ -208,6 +212,8 @@ class Runner:
 
                 async for event in current_agent.astream(new_message, ctx=ctx):
                     await self.session_service.append_event(session, event)
+                    if event.text:
+                        last_text = event.text
                     yield event
 
                     if event.actions and event.actions.transfer_to_agent:
@@ -222,6 +228,8 @@ class Runner:
 
                 current_agent = target
                 ctx = ctx.model_copy(update={"agent_name": target.name})
+        except GeneratorExit:
+            pass
         except BaseException as exc:
             _span_err = exc
             raise
@@ -229,7 +237,10 @@ class Runner:
             if _span_err is not None:
                 await error_agent_span(run_manager, _span_err)
             else:
-                await end_agent_span(run_manager)
+                await end_agent_span(
+                    run_manager,
+                    {"output": last_text} if last_text else None,
+                )
 
         # Run compaction after all events are yielded from the agent.
         # Only compact at the end of an invocation, never mid-stream.

--- a/orxhestra/runner.py
+++ b/orxhestra/runner.py
@@ -201,6 +201,7 @@ class Runner:
 
         current_agent = self.agent
 
+        _span_err: BaseException | None = None
         try:
             while True:
                 transfer_target: str | None = None
@@ -222,10 +223,13 @@ class Runner:
                 current_agent = target
                 ctx = ctx.model_copy(update={"agent_name": target.name})
         except BaseException as exc:
-            await error_agent_span(run_manager, exc)
+            _span_err = exc
             raise
-        else:
-            await end_agent_span(run_manager)
+        finally:
+            if _span_err is not None:
+                await error_agent_span(run_manager, _span_err)
+            else:
+                await end_agent_span(run_manager)
 
         # Run compaction after all events are yielded from the agent.
         # Only compact at the end of an invocation, never mid-stream.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ perplexity = ["langchain-perplexity>=0.1.0"]
 openrouter = ["langchain-openrouter>=0.1.0"]
 upstage = ["langchain-upstage>=0.3.0"]
 # Infrastructure
+auth = ["cryptography>=43.0", "base58>=2.1", "PyJWT>=2.8"]
 database = ["sqlalchemy[asyncio]>=2.0", "aiosqlite>=0.20"]
 mcp = ["fastmcp>=2.0.0"]
 composer = ["pyyaml>=6.0"]
@@ -61,6 +62,9 @@ all = [
     "prompt-toolkit>=3.0",
     "sqlalchemy[asyncio]>=2.0",
     "aiosqlite>=0.20",
+    "cryptography>=43.0",
+    "base58>=2.1",
+    "PyJWT>=2.8",
 ]
 
 [project.scripts]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,257 @@
+"""Tests for orxhestra.auth — SSRF, crypto, and token parsing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orxhestra.auth.ssrf import (
+    validate_and_pin_url,
+    validate_redirect_target,
+    validate_url_host,
+)
+
+
+class TestSSRF:
+    """Tests for SSRF protection utilities."""
+
+    def test_empty_hostname_blocked(self) -> None:
+        assert validate_url_host("") is not None
+
+    def test_localhost_blocked(self) -> None:
+        assert validate_url_host("localhost") is not None
+
+    def test_metadata_endpoint_blocked(self) -> None:
+        assert validate_url_host("169.254.169.254") is not None
+
+    def test_metadata_google_blocked(self) -> None:
+        assert validate_url_host("metadata.google.internal") is not None
+
+    def test_private_ip_blocked(self) -> None:
+        assert validate_url_host("10.0.0.1") is not None
+
+    def test_loopback_blocked(self) -> None:
+        assert validate_url_host("127.0.0.1") is not None
+
+    def test_local_suffix_blocked(self) -> None:
+        assert validate_url_host("myhost.local") is not None
+
+    def test_internal_suffix_blocked(self) -> None:
+        assert validate_url_host("api.internal") is not None
+
+    def test_public_hostname_allowed(self) -> None:
+        # google.com should not be blocked
+        assert validate_url_host("google.com") is None
+
+    def test_validate_and_pin_private_ip(self) -> None:
+        error, ips = validate_and_pin_url("http://127.0.0.1/secret")
+        assert error is not None
+        assert ips == []
+
+    def test_validate_and_pin_invalid_url(self) -> None:
+        error, ips = validate_and_pin_url("")
+        assert error is not None
+
+    def test_validate_and_pin_raw_public_ip(self) -> None:
+        error, ips = validate_and_pin_url("http://8.8.8.8/dns")
+        assert error is None
+        assert "8.8.8.8" in ips
+
+    def test_redirect_to_private_blocked(self) -> None:
+        error = validate_redirect_target("http://127.0.0.1/", "example.com")
+        assert error is not None
+
+    def test_redirect_to_public_allowed(self) -> None:
+        error = validate_redirect_target("https://example.com/callback", "example.com")
+        assert error is None
+
+
+crypto = pytest.importorskip("cryptography")
+base58_mod = pytest.importorskip("base58")
+
+from orxhestra.auth.crypto import (  # noqa: E402
+    canonicalize_json,
+    deserialize_private_key,
+    deserialize_public_key,
+    did_key_fragment,
+    did_key_to_public_key,
+    generate_ed25519_keypair,
+    load_or_create_signing_key,
+    public_key_to_did_key,
+    serialize_private_key,
+    serialize_public_key,
+    sign_json_payload,
+    sign_message,
+    verify_json_signature,
+    verify_signature,
+)
+
+
+class TestCrypto:
+    """Tests for Ed25519 cryptographic operations."""
+
+    def test_keypair_generation(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        assert priv is not None
+        assert pub is not None
+
+    def test_private_key_round_trip(self) -> None:
+        priv, _ = generate_ed25519_keypair()
+        raw: bytes = serialize_private_key(priv)
+        assert len(raw) == 32
+        restored = deserialize_private_key(raw)
+        assert serialize_private_key(restored) == raw
+
+    def test_public_key_round_trip(self) -> None:
+        _, pub = generate_ed25519_keypair()
+        raw: bytes = serialize_public_key(pub)
+        assert len(raw) == 32
+        restored = deserialize_public_key(raw)
+        assert serialize_public_key(restored) == raw
+
+    def test_sign_and_verify(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        message: bytes = b"hello orxhestra"
+        sig: bytes = sign_message(priv, message)
+        assert verify_signature(pub, sig, message)
+
+    def test_verify_wrong_message_fails(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        sig: bytes = sign_message(priv, b"correct")
+        assert not verify_signature(pub, sig, b"wrong")
+
+    def test_did_key_round_trip(self) -> None:
+        _, pub = generate_ed25519_keypair()
+        did: str = public_key_to_did_key(pub)
+        assert did.startswith("did:key:z")
+        restored = did_key_to_public_key(did)
+        assert serialize_public_key(restored) == serialize_public_key(pub)
+
+    def test_did_key_invalid_format(self) -> None:
+        with pytest.raises(ValueError, match="Invalid did:key"):
+            did_key_to_public_key("not-a-did")
+
+    def test_did_key_fragment(self) -> None:
+        _, pub = generate_ed25519_keypair()
+        did: str = public_key_to_did_key(pub)
+        frag: str = did_key_fragment(did)
+        assert frag.startswith("#z")
+
+    def test_canonicalize_json_sorted_keys(self) -> None:
+        payload: dict = {"b": 2, "a": 1}
+        result: bytes = canonicalize_json(payload)
+        assert json.loads(result) == {"a": 1, "b": 2}
+        # Keys should be sorted in the byte representation.
+        assert result.index(b'"a"') < result.index(b'"b"')
+
+    def test_canonicalize_json_compact(self) -> None:
+        payload: dict = {"key": "value"}
+        result: bytes = canonicalize_json(payload)
+        assert b" " not in result  # Compact separators.
+
+    def test_sign_and_verify_json(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        payload: dict = {"agent": "test", "action": "sign"}
+        sig: str = sign_json_payload(priv, payload)
+        assert verify_json_signature(pub, payload, sig)
+
+    def test_verify_json_tampered_fails(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        payload: dict = {"agent": "test"}
+        sig: str = sign_json_payload(priv, payload)
+        assert not verify_json_signature(pub, {"agent": "tampered"}, sig)
+
+    def test_load_or_create_signing_key_creates_new(self, tmp_path: Path) -> None:
+        key_file: Path = tmp_path / "signing_key.json"
+        priv, did = load_or_create_signing_key(key_file)
+        assert did.startswith("did:key:z")
+        assert key_file.exists()
+
+    def test_load_or_create_signing_key_loads_existing(self, tmp_path: Path) -> None:
+        key_file: Path = tmp_path / "signing_key.json"
+        priv1, did1 = load_or_create_signing_key(key_file)
+        priv2, did2 = load_or_create_signing_key(key_file)
+        assert did1 == did2
+        assert serialize_private_key(priv1) == serialize_private_key(priv2)
+
+    def test_load_or_create_signing_key_encrypted(self, tmp_path: Path) -> None:
+        key_file: Path = tmp_path / "encrypted_key.json"
+        priv1, did1 = load_or_create_signing_key(
+            key_file, encryption_password="test-password",
+        )
+        priv2, did2 = load_or_create_signing_key(
+            key_file, encryption_password="test-password",
+        )
+        assert did1 == did2
+        # Verify the file contains encrypted data, not plaintext.
+        data: dict = json.loads(key_file.read_text())
+        assert "private_key_encrypted" in data
+        assert "private_key_b64" not in data
+
+
+jwt_mod = pytest.importorskip("jwt")
+
+from orxhestra.auth.token_parser import (  # noqa: E402
+    TokenType,
+    detect_token_type,
+    extract_identity_from_token,
+    parse_jwt_claims,
+)
+
+
+class TestTokenParser:
+    """Tests for token type detection and JWT parsing."""
+
+    def test_detect_did(self) -> None:
+        assert detect_token_type("did:key:z6Mktest123") == TokenType.DID
+
+    def test_detect_url(self) -> None:
+        assert detect_token_type("https://example.com/agent") == TokenType.URL
+
+    def test_detect_unknown(self) -> None:
+        assert detect_token_type("short") == TokenType.UNKNOWN
+
+    def test_detect_jwt(self) -> None:
+        import jwt as pyjwt
+
+        token: str = pyjwt.encode({"sub": "agent-1"}, "secret", algorithm="HS256")
+        assert detect_token_type(token) == TokenType.JWT
+
+    def test_parse_jwt_claims(self) -> None:
+        import jwt as pyjwt
+
+        token: str = pyjwt.encode(
+            {"sub": "agent-1", "iss": "orxhestra", "scope": "read write"},
+            "secret",
+            algorithm="HS256",
+        )
+        parsed = parse_jwt_claims(token)
+        assert parsed is not None
+        assert parsed["subject"] == "agent-1"
+        assert parsed["issuer"] == "orxhestra"
+        assert parsed["scopes"] == ["read", "write"]
+
+    def test_parse_jwt_invalid(self) -> None:
+        assert parse_jwt_claims("not-a-jwt") is None
+
+    def test_extract_identity_did(self) -> None:
+        result = extract_identity_from_token("did:web:example.com")
+        assert result["token_type"] == "did"
+        assert result["did_method"] == "web"
+
+    def test_extract_identity_url(self) -> None:
+        result = extract_identity_from_token("https://agent.example.com")
+        assert result["token_type"] == "url"
+        assert "url" in result
+
+    def test_extract_identity_jwt(self) -> None:
+        import jwt as pyjwt
+
+        token: str = pyjwt.encode(
+            {"sub": "agent-1", "iss": "test"}, "secret", algorithm="HS256",
+        )
+        result = extract_identity_from_token(token)
+        assert result["token_type"] == "jwt"
+        assert result["subject"] == "agent-1"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,290 @@
+"""Tests for hierarchical tracing via LangChain's AsyncCallbackManager."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+from langchain_core.callbacks import AsyncCallbackHandler
+
+from orxhestra.agents.base_agent import BaseAgent
+from orxhestra.agents.invocation_context import InvocationContext
+from orxhestra.agents.sequential_agent import SequentialAgent
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
+from orxhestra.events.event import EventType
+from orxhestra.models.part import Content
+from orxhestra.runner import Runner
+from orxhestra.sessions.in_memory_session_service import InMemorySessionService
+
+
+class SpanRecorder(AsyncCallbackHandler):
+    """Records on_chain_start/on_chain_end calls with parent relationships."""
+
+    def __init__(self) -> None:
+        self.spans: list[dict[str, Any]] = []
+        self._open: dict[UUID, dict[str, Any]] = {}
+
+    async def on_chain_start(
+        self,
+        serialized: dict[str, Any],
+        inputs: dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        record = {
+            "name": serialized.get("name", ""),
+            "run_id": run_id,
+            "parent_run_id": parent_run_id,
+            "type": "chain_start",
+        }
+        self._open[run_id] = record
+        self.spans.append(record)
+
+    async def on_chain_end(
+        self,
+        outputs: dict[str, Any],
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        self.spans.append({
+            "run_id": run_id,
+            "type": "chain_end",
+        })
+
+    async def on_chain_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        **kwargs: Any,
+    ) -> None:
+        self.spans.append({
+            "run_id": run_id,
+            "type": "chain_error",
+        })
+
+    def started_names(self) -> list[str]:
+        return [s["name"] for s in self.spans if s["type"] == "chain_start"]
+
+    def parent_of(self, child_name: str) -> str | None:
+        for s in self.spans:
+            if s["type"] == "chain_start" and s["name"] == child_name:
+                pid = s["parent_run_id"]
+                if pid is None:
+                    return None
+                for p in self.spans:
+                    if p["type"] == "chain_start" and p["run_id"] == pid:
+                        return p["name"]
+        return None
+
+
+class StubAgent(BaseAgent):
+    """Agent that yields a fixed answer."""
+
+    def __init__(self, name: str = "stub", answer: str = "hello") -> None:
+        super().__init__(name=name)
+        self._answer = answer
+
+    async def astream(self, input: str, config=None, *, ctx=None):
+        ctx = self._ensure_ctx(config, ctx)
+        yield self._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text(self._answer),
+        )
+
+
+class TracedStubAgent(BaseAgent):
+    """Stub agent that emits its own trace span (like LlmAgent would)."""
+
+    def __init__(self, name: str = "traced_stub", answer: str = "ok") -> None:
+        super().__init__(name=name)
+        self._answer = answer
+
+    async def astream(self, input: str, config=None, *, ctx=None):
+        ctx = self._ensure_ctx(config, ctx)
+        ctx, run_mgr = await start_agent_span(
+            ctx, self.name, "TracedStubAgent", {"input": input},
+        )
+        try:
+            yield self._emit_event(
+                ctx,
+                EventType.AGENT_MESSAGE,
+                content=Content.from_text(self._answer),
+            )
+        except BaseException as exc:
+            await error_agent_span(run_mgr, exc)
+            raise
+        else:
+            await end_agent_span(run_mgr)
+
+
+# ── Unit tests for start/end/error_agent_span ────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_agent_span_no_callbacks() -> None:
+    """When no callbacks are configured, ctx is returned unchanged."""
+    ctx = InvocationContext(session_id="s1", agent_name="test")
+    new_ctx, run_mgr = await start_agent_span(
+        ctx, "test", "TestAgent", {"input": "hi"},
+    )
+    assert run_mgr is None
+    assert new_ctx is ctx
+
+
+@pytest.mark.asyncio
+async def test_start_agent_span_empty_callbacks() -> None:
+    """Empty callbacks list is treated as no callbacks."""
+    ctx = InvocationContext(
+        session_id="s1", agent_name="test", run_config={"callbacks": []},
+    )
+    new_ctx, run_mgr = await start_agent_span(
+        ctx, "test", "TestAgent", {"input": "hi"},
+    )
+    assert run_mgr is None
+
+
+@pytest.mark.asyncio
+async def test_start_agent_span_creates_child_manager() -> None:
+    """With callbacks, a child manager replaces run_config callbacks."""
+    recorder = SpanRecorder()
+    ctx = InvocationContext(
+        session_id="s1",
+        agent_name="test",
+        run_config={"callbacks": [recorder]},
+    )
+    new_ctx, run_mgr = await start_agent_span(
+        ctx, "MyAgent", "LlmAgent", {"input": "hi"},
+    )
+    assert run_mgr is not None
+    assert new_ctx is not ctx
+    # The new config's callbacks should be a child manager, not the original list
+    assert new_ctx.run_config["callbacks"] is not ctx.run_config["callbacks"]
+
+    await end_agent_span(run_mgr)
+
+    assert recorder.started_names() == ["MyAgent"]
+
+
+@pytest.mark.asyncio
+async def test_error_agent_span_records_error() -> None:
+    """Error span fires on_chain_error."""
+    recorder = SpanRecorder()
+    ctx = InvocationContext(
+        session_id="s1",
+        agent_name="test",
+        run_config={"callbacks": [recorder]},
+    )
+    _, run_mgr = await start_agent_span(
+        ctx, "FailAgent", "LlmAgent", {"input": "hi"},
+    )
+    await error_agent_span(run_mgr, RuntimeError("boom"))
+
+    error_events = [s for s in recorder.spans if s["type"] == "chain_error"]
+    assert len(error_events) == 1
+
+
+# ── Integration: Runner root span ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runner_creates_root_span() -> None:
+    """Runner wraps agent execution in a root trace span."""
+    recorder = SpanRecorder()
+    runner = Runner(
+        agent=StubAgent(answer="hi"),
+        app_name="test-app",
+        session_service=InMemorySessionService(),
+    )
+
+    events = [
+        e async for e in runner.astream(
+            user_id="u1",
+            session_id="s1",
+            new_message="hello",
+            config={"callbacks": [recorder]},
+        )
+    ]
+
+    assert len(events) == 1
+    assert events[0].text == "hi"
+
+    names = recorder.started_names()
+    assert any("Runner:" in n for n in names)
+
+    end_events = [s for s in recorder.spans if s["type"] == "chain_end"]
+    assert len(end_events) >= 1
+
+
+# ── Integration: nested spans via SequentialAgent ────────────
+
+
+@pytest.mark.asyncio
+async def test_sequential_agent_nested_spans() -> None:
+    """SequentialAgent with traced children creates nested spans."""
+    recorder = SpanRecorder()
+
+    agent1 = TracedStubAgent(name="agent_a", answer="result_a")
+    agent2 = TracedStubAgent(name="agent_b", answer="result_b")
+    pipeline = SequentialAgent(
+        name="pipeline", agents=[agent1, agent2],
+    )
+
+    runner = Runner(
+        agent=pipeline,
+        app_name="test-app",
+        session_service=InMemorySessionService(),
+    )
+
+    events = [
+        e async for e in runner.astream(
+            user_id="u1",
+            session_id="s1",
+            new_message="go",
+            config={"callbacks": [recorder]},
+        )
+    ]
+
+    assert len(events) == 2
+
+    names = recorder.started_names()
+    # Expect: Runner:pipeline, pipeline, agent_a, agent_b
+    assert "pipeline" in names
+    assert "agent_a" in names
+    assert "agent_b" in names
+
+    # Verify nesting: agent_a's parent should be pipeline
+    assert recorder.parent_of("agent_a") == "pipeline"
+    assert recorder.parent_of("agent_b") == "pipeline"
+
+    # pipeline's parent should be the Runner span
+    pipeline_parent = recorder.parent_of("pipeline")
+    assert pipeline_parent is not None
+    assert "Runner:" in pipeline_parent
+
+
+# ── No-callbacks path has zero overhead ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_callbacks_no_overhead() -> None:
+    """Without callbacks, agents produce events normally."""
+    runner = Runner(
+        agent=TracedStubAgent(answer="ok"),
+        app_name="app",
+        session_service=InMemorySessionService(),
+    )
+
+    events = [
+        e async for e in runner.astream(
+            user_id="u1", session_id="s1", new_message="hi",
+        )
+    ]
+
+    assert len(events) == 1
+    assert events[0].text == "ok"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -11,7 +11,7 @@ from langchain_core.callbacks import AsyncCallbackHandler
 from orxhestra.agents.base_agent import BaseAgent
 from orxhestra.agents.invocation_context import InvocationContext
 from orxhestra.agents.sequential_agent import SequentialAgent
-from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
+from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span, trace
 from orxhestra.events.event import EventType
 from orxhestra.models.part import Content
 from orxhestra.runner import Runner
@@ -68,9 +68,11 @@ class SpanRecorder(AsyncCallbackHandler):
         })
 
     def started_names(self) -> list[str]:
+        """Return names of all chain_start spans."""
         return [s["name"] for s in self.spans if s["type"] == "chain_start"]
 
     def parent_of(self, child_name: str) -> str | None:
+        """Return the name of the parent span for a given child name."""
         for s in self.spans:
             if s["type"] == "chain_start" and s["name"] == child_name:
                 pid = s["parent_run_id"]
@@ -83,7 +85,7 @@ class SpanRecorder(AsyncCallbackHandler):
 
 
 class StubAgent(BaseAgent):
-    """Agent that yields a fixed answer."""
+    """Agent that yields a fixed answer without tracing."""
 
     def __init__(self, name: str = "stub", answer: str = "hello") -> None:
         super().__init__(name=name)
@@ -99,31 +101,19 @@ class StubAgent(BaseAgent):
 
 
 class TracedStubAgent(BaseAgent):
-    """Stub agent that emits its own trace span (like LlmAgent would)."""
+    """Stub agent that uses the @traced decorator."""
 
     def __init__(self, name: str = "traced_stub", answer: str = "ok") -> None:
         super().__init__(name=name)
         self._answer = answer
 
+    @trace("TracedStubAgent")
     async def astream(self, input: str, config=None, *, ctx=None):
-        ctx = self._ensure_ctx(config, ctx)
-        ctx, run_mgr = await start_agent_span(
-            ctx, self.name, "TracedStubAgent", {"input": input},
+        yield self._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text(self._answer),
         )
-        try:
-            yield self._emit_event(
-                ctx,
-                EventType.AGENT_MESSAGE,
-                content=Content.from_text(self._answer),
-            )
-        except BaseException as exc:
-            await error_agent_span(run_mgr, exc)
-            raise
-        else:
-            await end_agent_span(run_mgr)
-
-
-# ── Unit tests for start/end/error_agent_span ────────────────
 
 
 @pytest.mark.asyncio
@@ -163,7 +153,6 @@ async def test_start_agent_span_creates_child_manager() -> None:
     )
     assert run_mgr is not None
     assert new_ctx is not ctx
-    # The new config's callbacks should be a child manager, not the original list
     assert new_ctx.run_config["callbacks"] is not ctx.run_config["callbacks"]
 
     await end_agent_span(run_mgr)
@@ -187,9 +176,6 @@ async def test_error_agent_span_records_error() -> None:
 
     error_events = [s for s in recorder.spans if s["type"] == "chain_error"]
     assert len(error_events) == 1
-
-
-# ── Integration: Runner root span ────────────────────────────
 
 
 @pytest.mark.asyncio
@@ -221,9 +207,6 @@ async def test_runner_creates_root_span() -> None:
     assert len(end_events) >= 1
 
 
-# ── Integration: nested spans via SequentialAgent ────────────
-
-
 @pytest.mark.asyncio
 async def test_sequential_agent_nested_spans() -> None:
     """SequentialAgent with traced children creates nested spans."""
@@ -253,7 +236,6 @@ async def test_sequential_agent_nested_spans() -> None:
     assert len(events) == 2
 
     names = recorder.started_names()
-    # Expect: Runner:pipeline, pipeline, agent_a, agent_b
     assert "pipeline" in names
     assert "agent_a" in names
     assert "agent_b" in names
@@ -266,9 +248,6 @@ async def test_sequential_agent_nested_spans() -> None:
     pipeline_parent = recorder.parent_of("pipeline")
     assert pipeline_parent is not None
     assert "Runner:" in pipeline_parent
-
-
-# ── No-callbacks path has zero overhead ──────────────────────
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Port attestix auth patterns into orxhestra/auth/
- Ed25519 crypto, DID:key, RFC 8785 JSON canonicalization, signing key persistence
- JWT/DID/URL/API key classification and claim extraction
- SSRF protection (stdlib only, no deps)
- Optional deps via `pip install orxhestra[auth]`
- 38 new tests, PEP 257 docstrings throughout

## Test plan
- [x] 376 tests pass (38 new + 338 existing)
- [x] Ruff clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)