### PR TITLE
Add signed events and per-agent identity

### DIFF
--- a/orxhestra/agents/base_agent.py
+++ b/orxhestra/agents/base_agent.py
@@ -41,13 +41,29 @@ class BaseAgent(ABC):
         Child agents registered under this agent.
     parent_agent : BaseAgent, optional
         The parent agent (set automatically on registration).
+    signing_key : Ed25519PrivateKey, optional
+        Ed25519 private key giving this agent its own identity.
+        When set, events emitted by this agent are signed with
+        this key (takes priority over the context-level key).
+        Requires ``orxhestra[auth]``.
+    signing_did : str
+        The ``did:key`` identifier for ``signing_key``.
     """
 
-    def __init__(self, name: str, description: str = "") -> None:
+    def __init__(
+        self,
+        name: str,
+        description: str = "",
+        *,
+        signing_key: Any | None = None,
+        signing_did: str = "",
+    ) -> None:
         self.name = name
         self.description = description
         self.sub_agents: list[BaseAgent] = []
         self.parent_agent: BaseAgent | None = None
+        self.signing_key: Any | None = signing_key
+        self.signing_did: str = signing_did
 
     def _ensure_ctx(
         self,
@@ -88,7 +104,7 @@ class BaseAgent(ABC):
             A new Event with branch, session_id, and agent_name set.
         """
         kwargs.setdefault("author", self.name)
-        return Event(
+        event = Event(
             type=type,
             session_id=ctx.session_id,
             invocation_id=ctx.invocation_id,
@@ -96,6 +112,19 @@ class BaseAgent(ABC):
             branch=ctx.branch,
             **kwargs,
         )
+        key = self.signing_key or ctx.signing_key
+        did = self.signing_did or ctx.signing_did
+        if key is not None and did:
+            try:
+                from orxhestra.auth.crypto import sign_json_payload
+
+                event.signature = sign_json_payload(
+                    key, event.signable_payload(),
+                )
+                event.signer_did = did
+            except ImportError:
+                pass
+        return event
 
 
     @abstractmethod

--- a/orxhestra/agents/invocation_context.py
+++ b/orxhestra/agents/invocation_context.py
@@ -79,29 +79,100 @@ class InvocationContext(BaseModel):
         Optional memory service for long-term recall.
     event_callback : callable, optional
         Callback for real-time event streaming to parent agents.
+    signing_key : Ed25519PrivateKey, optional
+        Ed25519 private key for signing events.  When set, every event
+        emitted by ``BaseAgent._emit_event`` is signed automatically.
+        Install ``orxhestra[auth]`` to use this feature.
+    signing_did : str
+        The ``did:key`` identifier corresponding to ``signing_key``.
+        Attached to each signed event so verifiers can look up the
+        public key.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    invocation_id: str = Field(default_factory=lambda: str(uuid4()))
-    session_id: str
-    user_id: str = ""
-    app_name: str = ""
-    agent_name: str
-    branch: str = ""
-    state: dict[str, Any] = Field(default_factory=dict)
-    agent_states: dict[str, dict[str, Any]] = Field(default_factory=dict)
-    end_of_agents: dict[str, bool] = Field(default_factory=dict)
-    end_invocation: bool = False
-    is_resumable: bool = False
-    long_running_tool_ids: set[str] = Field(default_factory=set)
-    input_content: str | None = None
-    session: Any | None = None
-    run_config: dict[str, Any] = Field(default_factory=dict)
-    current_agent: BaseAgent | None = None
-    artifact_service: BaseArtifactService | None = None
-    memory_service: Any | None = None
-    event_callback: Callable[[Any], None] | None = None
+    invocation_id: str = Field(
+        default_factory=lambda: str(uuid4()),
+        description="Unique ID for this specific invocation.",
+    )
+    session_id: str = Field(
+        description="The session this invocation belongs to.",
+    )
+    user_id: str = Field(
+        default="",
+        description="The user who initiated the session.",
+    )
+    app_name: str = Field(
+        default="",
+        description="The application running the agent.",
+    )
+    agent_name: str = Field(
+        description="The name of the currently executing agent.",
+    )
+    branch: str = Field(
+        default="",
+        description="Dot-separated path for nested execution (e.g. 'root.child').",
+    )
+    state: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Mutable key-value store for cross-agent state within one run.",
+    )
+    agent_states: dict[str, dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Per-agent execution state for composite agents.",
+    )
+    end_of_agents: dict[str, bool] = Field(
+        default_factory=dict,
+        description="Tracks which agents have finished their turn.",
+    )
+    end_invocation: bool = Field(
+        default=False,
+        description="Kill switch to force-stop the entire invocation.",
+    )
+    is_resumable: bool = Field(
+        default=False,
+        description="When True, enables pause/resume for long-running tools.",
+    )
+    long_running_tool_ids: set[str] = Field(
+        default_factory=set,
+        description="Tool call IDs that should trigger invocation pause.",
+    )
+    input_content: str | None = Field(
+        default=None,
+        description="The input that initiated this invocation, preserved for resumption.",
+    )
+    session: Any | None = Field(
+        default=None,
+        description="The session object this invocation belongs to.",
+    )
+    run_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Per-run configuration (LangChain RunnableConfig / AgentConfig).",
+    )
+    current_agent: BaseAgent | None = Field(
+        default=None,
+        description="Reference to the current agent instance.",
+    )
+    artifact_service: BaseArtifactService | None = Field(
+        default=None,
+        description="Service for storing and retrieving file artifacts.",
+    )
+    memory_service: Any | None = Field(
+        default=None,
+        description="Optional memory service for long-term recall.",
+    )
+    event_callback: Callable[[Any], None] | None = Field(
+        default=None,
+        description="Callback for real-time event streaming to parent agents.",
+    )
+    signing_key: Any | None = Field(
+        default=None,
+        description="Ed25519 private key for signing events. Requires orxhestra[auth].",
+    )
+    signing_did: str = Field(
+        default="",
+        description="The did:key identifier corresponding to signing_key.",
+    )
 
     def derive(
         self,
@@ -144,6 +215,8 @@ class InvocationContext(BaseModel):
                 "artifact_service": self.artifact_service,
                 "memory_service": self.memory_service,
                 "event_callback": self.event_callback,
+                "signing_key": self.signing_key,
+                "signing_did": self.signing_did,
             }
         )
 

--- a/orxhestra/agents/llm_agent.py
+++ b/orxhestra/agents/llm_agent.py
@@ -158,8 +158,15 @@ class LlmAgent(BaseAgent):
         tool_response_max_chars: int = 30_000,
         context_max_chars: int = 5_000,
         context_total_max_chars: int = 10_000,
+        signing_key: Any | None = None,
+        signing_did: str = "",
     ) -> None:
-        super().__init__(name=name, description=description)
+        super().__init__(
+            name=name,
+            description=description,
+            signing_key=signing_key,
+            signing_did=signing_did,
+        )
 
         self._llm = llm
         self._tools: dict[str, BaseTool] = {t.name: t for t in (tools or [])}

--- a/orxhestra/events/event.py
+++ b/orxhestra/events/event.py
@@ -77,6 +77,15 @@ class Event(BaseModel):
         Arbitrary extra metadata (react_step, error, scratchpad, etc.).
     llm_response : LlmResponse, optional
         The raw LLM response (internal use).
+    signature : str, optional
+        Base64url-encoded Ed25519 signature over the canonical JSON
+        representation of the event's signable fields (id, type,
+        timestamp, agent_name, content text).  Set automatically
+        when the emitting agent has a signing key.
+    signer_did : str
+        The ``did:key`` identifier of the signing agent.  Verifiers
+        use this to resolve the public key via
+        ``orxhestra.auth.did_key_to_public_key()``.
     """
 
     id: str = Field(default_factory=lambda: str(uuid4()))
@@ -95,6 +104,8 @@ class Event(BaseModel):
     actions: EventActions = Field(default_factory=EventActions)
     metadata: dict[str, Any] = Field(default_factory=dict)
     llm_response: LlmResponse | None = None
+    signature: str | None = None
+    signer_did: str = ""
 
     @property
     def text(self) -> str:
@@ -240,6 +251,65 @@ class Event(BaseModel):
         if self.metadata.get("error"):
             return self.text
         return None
+
+    def signable_payload(self) -> dict[str, Any]:
+        """Return the canonical dict of fields included in the signature.
+
+        Returns
+        -------
+        dict[str, Any]
+            Deterministic subset of event fields used for signing
+            and verification.
+        """
+        return {
+            "id": self.id,
+            "type": self.type.value,
+            "timestamp": self.timestamp,
+            "agent_name": self.agent_name or "",
+            "branch": self.branch,
+            "content_text": self.text,
+        }
+
+    @property
+    def is_signed(self) -> bool:
+        """Return ``True`` if this event carries a signature."""
+        return self.signature is not None and bool(self.signer_did)
+
+    def verify_signature(self) -> bool:
+        """Verify this event's signature using the signer's DID.
+
+        Resolves the public key from ``signer_did`` via
+        ``orxhestra.auth.did_key_to_public_key()`` and verifies the
+        signature over :meth:`signable_payload`.
+
+        Returns
+        -------
+        bool
+            ``True`` if the signature is valid.  ``False`` if the
+            event is unsigned, the DID is invalid, or verification
+            fails.
+
+        Raises
+        ------
+        ImportError
+            If ``orxhestra[auth]`` is not installed.
+        """
+        if not self.is_signed:
+            return False
+
+        from orxhestra.auth.crypto import (
+            did_key_to_public_key,
+            verify_json_signature,
+        )
+
+        try:
+            public_key = did_key_to_public_key(self.signer_did)
+        except ValueError:
+            return False
+
+        return verify_json_signature(
+            public_key, self.signable_payload(), self.signature,
+        )
 
     @staticmethod
     def new_id() -> str:

--- a/tests/test_signed_events.py
+++ b/tests/test_signed_events.py
@@ -1,0 +1,142 @@
+"""Tests for signed events — Ed25519 signatures on Event objects."""
+
+from __future__ import annotations
+
+import pytest
+
+crypto = pytest.importorskip("cryptography")
+base58_mod = pytest.importorskip("base58")
+
+from orxhestra.agents.base_agent import BaseAgent  # noqa: E402
+from orxhestra.agents.invocation_context import InvocationContext  # noqa: E402
+from orxhestra.auth.crypto import (  # noqa: E402
+    generate_ed25519_keypair,
+    public_key_to_did_key,
+)
+from orxhestra.events.event import Event, EventType  # noqa: E402
+from orxhestra.models.part import Content  # noqa: E402
+
+
+def _signed_ctx(**kwargs) -> InvocationContext:
+    """Create a context with a fresh signing key."""
+    priv, pub = generate_ed25519_keypair()
+    did = public_key_to_did_key(pub)
+    defaults = {
+        "session_id": "test",
+        "agent_name": "agent",
+        "signing_key": priv,
+        "signing_did": did,
+    }
+    defaults.update(kwargs)
+    return InvocationContext(**defaults)
+
+
+def _unsigned_ctx(**kwargs) -> InvocationContext:
+    """Create a context without a signing key."""
+    defaults = {"session_id": "test", "agent_name": "agent"}
+    defaults.update(kwargs)
+    return InvocationContext(**defaults)
+
+
+class _DummyAgent(BaseAgent):
+    """Minimal agent for testing _emit_event."""
+
+    async def astream(self, input, config=None, *, ctx=None):
+        yield  # pragma: no cover
+
+
+class TestSignedEvents:
+    """Tests for automatic event signing via _emit_event."""
+
+    def test_event_signed_when_key_present(self) -> None:
+        agent = _DummyAgent(name="agent")
+        ctx = _signed_ctx()
+        event = agent._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text("hello"),
+        )
+        assert event.is_signed
+        assert event.signature is not None
+        assert event.signer_did.startswith("did:key:z")
+
+    def test_event_unsigned_when_no_key(self) -> None:
+        agent = _DummyAgent(name="agent")
+        ctx = _unsigned_ctx()
+        event = agent._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text("hello"),
+        )
+        assert not event.is_signed
+        assert event.signature is None
+        assert event.signer_did == ""
+
+    def test_signed_event_verifies(self) -> None:
+        agent = _DummyAgent(name="agent")
+        ctx = _signed_ctx()
+        event = agent._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text("trusted output"),
+        )
+        assert event.verify_signature()
+
+    def test_tampered_event_fails_verification(self) -> None:
+        agent = _DummyAgent(name="agent")
+        ctx = _signed_ctx()
+        event = agent._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text("original"),
+        )
+        event.content = Content.from_text("tampered")
+        assert not event.verify_signature()
+
+    def test_wrong_did_fails_verification(self) -> None:
+        agent = _DummyAgent(name="agent")
+        ctx = _signed_ctx()
+        event = agent._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text("hello"),
+        )
+        _, other_pub = generate_ed25519_keypair()
+        event.signer_did = public_key_to_did_key(other_pub)
+        assert not event.verify_signature()
+
+    def test_unsigned_event_verify_returns_false(self) -> None:
+        event = Event(
+            type=EventType.AGENT_MESSAGE,
+            content=Content.from_text("no sig"),
+        )
+        assert not event.verify_signature()
+
+    def test_signing_key_propagates_through_derive(self) -> None:
+        parent_ctx = _signed_ctx()
+        child_ctx = parent_ctx.derive(agent_name="child")
+        assert child_ctx.signing_key is parent_ctx.signing_key
+        assert child_ctx.signing_did == parent_ctx.signing_did
+
+    def test_tool_response_event_signed(self) -> None:
+        agent = _DummyAgent(name="agent")
+        ctx = _signed_ctx()
+        event = agent._emit_event(
+            ctx,
+            EventType.TOOL_RESPONSE,
+            content=Content.from_text("tool result"),
+        )
+        assert event.is_signed
+        assert event.verify_signature()
+
+    def test_signable_payload_deterministic(self) -> None:
+        agent = _DummyAgent(name="agent")
+        ctx = _signed_ctx()
+        event = agent._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text("deterministic"),
+        )
+        p1 = event.signable_payload()
+        p2 = event.signable_payload()
+        assert p1 == p2


### PR DESCRIPTION
## Summary
- Auto-sign events with Ed25519 when signing key is present
- Per-agent identity (`signing_key` on BaseAgent) or per-context (`signing_key` on InvocationContext)
- `Event.verify_signature()` resolves public key from DID and verifies
- `Field()` descriptors with descriptions on all InvocationContext fields

## Test plan
- [x] 385 tests pass (9 new + 376 existing)
- [x] Ruff clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)