### PR TITLE
Add thinking/reasoning token streaming

### DIFF
--- a/orxhestra/__init__.py
+++ b/orxhestra/__init__.py
@@ -38,7 +38,7 @@ Composer::
     from orxhestra.composer import Composer
 """
 
-__version__ = "0.0.40"
+__version__ = "0.0.41"
 
 from orxhestra.agents import (
     AgentConfig,
@@ -66,6 +66,7 @@ from orxhestra.models.part import (
     DataPart,
     FilePart,
     TextPart,
+    ThinkingPart,
     ToolCallPart,
     ToolResponsePart,
 )
@@ -101,6 +102,7 @@ __all__ = [
     "TextPart",
     "DataPart",
     "FilePart",
+    "ThinkingPart",
     "ToolCallPart",
     "ToolResponsePart",
     # Context

--- a/orxhestra/agents/llm_agent.py
+++ b/orxhestra/agents/llm_agent.py
@@ -73,6 +73,7 @@ if TYPE_CHECKING:
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+
 class LlmAgent(BaseAgent):
     """Agent with a manual tool-call loop.
 
@@ -207,15 +208,11 @@ class LlmAgent(BaseAgent):
             callbacks=self._callbacks,
             emit_event=self._emit_event,
         )
-        self._planner_adapter: PlannerAdapter | None = (
-            PlannerAdapter(planner) if planner else None
-        )
+        self._planner_adapter: PlannerAdapter | None = PlannerAdapter(planner) if planner else None
         # Keep raw reference for subclass access (e.g. ReActAgent).
         self._planner = planner
         self._structured_parser: StructuredOutputParser | None = (
-            StructuredOutputParser(llm, output_schema)
-            if output_schema
-            else None
+            StructuredOutputParser(llm, output_schema) if output_schema else None
         )
 
     @property
@@ -275,8 +272,7 @@ class LlmAgent(BaseAgent):
     ) -> LlmRequest:
         """Package the current turn into an ``LlmRequest``."""
         return LlmRequest(
-            model=getattr(self._llm, "model_name", None)
-            or getattr(self._llm, "model", None),
+            model=getattr(self._llm, "model_name", None) or getattr(self._llm, "model", None),
             system_instruction=system_instruction,
             messages=list(messages),
             tools=list(self._tools.values()),
@@ -303,8 +299,7 @@ class LlmAgent(BaseAgent):
             chunks.append(chunk)
 
             if not has_tool_calls and (
-                getattr(chunk, "tool_calls", None)
-                or getattr(chunk, "tool_call_chunks", None)
+                getattr(chunk, "tool_calls", None) or getattr(chunk, "tool_call_chunks", None)
             ):
                 has_tool_calls = True
 
@@ -312,12 +307,28 @@ class LlmAgent(BaseAgent):
                 continue
 
             chunk_text: str = ""
+            chunk_thinking: str = ""
             if isinstance(chunk.content, str):
                 chunk_text = chunk.content
             elif isinstance(chunk.content, list):
                 for part in chunk.content:
                     if isinstance(part, dict):
-                        chunk_text += part.get("text", "")
+                        ptype = part.get("type")
+                        if ptype == "thinking":
+                            chunk_thinking += part.get("thinking", "")
+                        elif ptype == "reasoning":
+                            chunk_thinking += part.get("reasoning", "")
+                        else:
+                            chunk_text += part.get("text", "")
+
+            if chunk_thinking:
+                yield self._emit_event(
+                    ctx,
+                    EventType.AGENT_MESSAGE,
+                    content=Content.from_thinking(chunk_thinking),
+                    partial=True,
+                    turn_complete=False,
+                )
 
             if chunk_text:
                 yield self._emit_event(
@@ -351,9 +362,7 @@ class LlmAgent(BaseAgent):
             async for item in self._call_llm(llm, messages, ctx):
                 yield item
         except Exception as exc:
-            recovered: AIMessage | None = await self._handle_llm_error(
-                ctx, request, exc
-            )
+            recovered: AIMessage | None = await self._handle_llm_error(ctx, request, exc)
             if recovered is not None:
                 yield recovered
             else:
@@ -367,9 +376,7 @@ class LlmAgent(BaseAgent):
     ) -> AIMessage | None:
         """Handle an LLM call error, returning a recovery message or ``None``."""
         if self._callbacks.on_model_error:
-            recovery: LlmResponse | None = await self._callbacks.on_model_error(
-                ctx, request, exc
-            )
+            recovery: LlmResponse | None = await self._callbacks.on_model_error(ctx, request, exc)
             if recovery is not None:
                 return AIMessage(content=recovery.text or "")
         return None
@@ -412,9 +419,7 @@ class LlmAgent(BaseAgent):
 
         # Parse structured output if schema is set.
         if self._structured_parser is not None:
-            structured = await self._structured_parser.parse(
-                answer_text, messages, ctx
-            )
+            structured = await self._structured_parser.parse(answer_text, messages, ctx)
             if structured is not None:
                 parts.append(DataPart(data=structured.model_dump()))
 
@@ -431,7 +436,6 @@ class LlmAgent(BaseAgent):
             )
 
         return self._emit_event(ctx, EventType.AGENT_MESSAGE, **emit_kwargs)
-
 
     @trace("LlmAgent")
     async def astream(
@@ -461,9 +465,7 @@ class LlmAgent(BaseAgent):
             Events emitted during execution, including partial streaming
             tokens, tool call/response events, and the final answer.
         """
-        system_prompt, messages = (
-            await self._message_builder.build_conversation_history(ctx, input)
-        )
+        system_prompt, messages = await self._message_builder.build_conversation_history(ctx, input)
         llm: BaseChatModel = self._build_bound_llm()
 
         for _ in range(self.max_iterations):
@@ -495,9 +497,7 @@ class LlmAgent(BaseAgent):
 
             # Call LLM with error recovery.
             raw_response: AIMessage | None = None
-            async for item in self._call_llm_with_recovery(
-                llm, messages, ctx, request
-            ):
+            async for item in self._call_llm_with_recovery(llm, messages, ctx, request):
                 if isinstance(item, AIMessage):
                     raw_response = item
                 elif item is None:
@@ -517,9 +517,7 @@ class LlmAgent(BaseAgent):
             # Post-process response.
             llm_response: LlmResponse = LlmResponse.from_ai_message(raw_response)
             if self._planner_adapter is not None:
-                llm_response = self._planner_adapter.process_response(
-                    ctx, llm_response
-                )
+                llm_response = self._planner_adapter.process_response(ctx, llm_response)
 
             if self._callbacks.after_model:
                 await self._callbacks.after_model(ctx, llm_response)
@@ -543,9 +541,7 @@ class LlmAgent(BaseAgent):
                     event, tool_msg = item
                     yield event
                     tool_messages.append(
-                        _truncate_tool_message(
-                            tool_msg, self.tool_response_max_chars
-                        )
+                        _truncate_tool_message(tool_msg, self.tool_response_max_chars)
                     )
                 else:
                     yield item
@@ -556,8 +552,7 @@ class LlmAgent(BaseAgent):
             ctx,
             EventType.AGENT_MESSAGE,
             content=Content.from_text(
-                f"Max iterations ({self.max_iterations}) reached "
-                f"without a final answer."
+                f"Max iterations ({self.max_iterations}) reached without a final answer."
             ),
             metadata={"error": True},
         )

--- a/orxhestra/cli/stream.py
+++ b/orxhestra/cli/stream.py
@@ -69,6 +69,7 @@ class _StreamState:
 
     buffer: str = ""
     in_stream: bool = False
+    thinking_active: bool = False
     live: Any = None
     status: Any = None
     tool_start: float = 0.0
@@ -230,9 +231,7 @@ async def stream_response(
                     if state.status is None:
                         break
                     new_phrase = _spinner_text(todo_list)
-                    state.status.update(
-                        f"  [orx.accent]{new_phrase}...[/orx.accent]"
-                    )
+                    state.status.update(f"  [orx.accent]{new_phrase}...[/orx.accent]")
             except asyncio.CancelledError:
                 pass
 
@@ -248,8 +247,24 @@ async def stream_response(
         ):
             s.accumulate_usage(event)
 
+            if event.partial and event.type == EventType.AGENT_MESSAGE and event.thinking:
+                s.stop_status()
+                if not s.thinking_active:
+                    s.thinking_active = True
+                    console.print(
+                        "[orx.thinking]  thinking ...[/orx.thinking]",
+                    )
+                console.print(
+                    f"[orx.thinking]{event.thinking}[/orx.thinking]",
+                    end="",
+                )
+                continue
+
             if event.partial and event.type == EventType.AGENT_MESSAGE and event.text:
                 s.stop_status()
+                if s.thinking_active:
+                    console.print()  # newline after thinking
+                    s.thinking_active = False
                 s.buffer += event.text
                 if Live is not None:
                     if not s.in_stream:
@@ -339,9 +354,7 @@ async def stream_response(
                         else ""
                     )
                     if agent_label:
-                        console.print(
-                            f"\n[orx.agent]{agent_label}[/orx.agent]"
-                        )
+                        console.print(f"\n[orx.agent]{agent_label}[/orx.agent]")
                     console.print(
                         f"[orx.muted]{RESPONSE_CONNECTOR}[/orx.muted] ",
                         end="",

--- a/orxhestra/cli/theme.py
+++ b/orxhestra/cli/theme.py
@@ -71,6 +71,7 @@ def _build_theme(palette: dict[str, str]) -> Theme:
             "orx.denied": m,
             "orx.interrupted": m,
             "orx.goodbye": m,
+            "orx.thinking": f"dim italic {m}",
             "orx.status": m,
             # Rich Markdown overrides
             "markdown.item.bullet": f"bold {a}",

--- a/orxhestra/models/__init__.py
+++ b/orxhestra/models/__init__.py
@@ -1,6 +1,6 @@
 from orxhestra.models.llm_request import LlmRequest
 from orxhestra.models.llm_response import LlmResponse
-from orxhestra.models.part import Content, DataPart, FilePart, Part, TextPart
+from orxhestra.models.part import Content, DataPart, FilePart, Part, TextPart, ThinkingPart
 
 __all__ = [
     "LlmResponse",
@@ -9,5 +9,6 @@ __all__ = [
     "TextPart",
     "DataPart",
     "FilePart",
+    "ThinkingPart",
     "Part",
 ]

--- a/orxhestra/models/llm_response.py
+++ b/orxhestra/models/llm_response.py
@@ -82,6 +82,7 @@ class LlmResponse(BaseModel):
             text = " ".join(
                 block.get("text", "") if isinstance(block, dict) else str(block)
                 for block in content
+                if not (isinstance(block, dict) and block.get("type") in ("thinking", "reasoning"))
             ).strip()
         else:
             text = str(content) if content else ""
@@ -91,8 +92,7 @@ class LlmResponse(BaseModel):
         output_tokens = usage.get("output_tokens") if usage else None
 
         model_version = (
-            message.response_metadata.get("model_name")
-            or message.response_metadata.get("model")
+            message.response_metadata.get("model_name") or message.response_metadata.get("model")
             if hasattr(message, "response_metadata") and message.response_metadata
             else None
         )

--- a/orxhestra/models/part.py
+++ b/orxhestra/models/part.py
@@ -77,6 +77,24 @@ class FilePart(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
+class ThinkingPart(BaseModel):
+    """A thinking/reasoning content part from extended thinking models.
+
+    Attributes
+    ----------
+    type : str
+        Part discriminator, always ``"thinking"``.
+    thinking : str
+        The thinking/reasoning text.
+    metadata : dict[str, Any]
+        Arbitrary key-value metadata attached to this part.
+    """
+
+    type: Literal["thinking"] = "thinking"
+    thinking: str
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
 class ToolCallPart(BaseModel):
     """A tool/function call part — the agent wants to invoke a tool.
 
@@ -129,7 +147,7 @@ class ToolResponsePart(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
-Part = TextPart | DataPart | FilePart | ToolCallPart | ToolResponsePart
+Part = TextPart | DataPart | FilePart | ThinkingPart | ToolCallPart | ToolResponsePart
 
 
 class Content(BaseModel):
@@ -154,6 +172,11 @@ class Content(BaseModel):
         return Content(role=role, parts=[TextPart(text=text)])
 
     @staticmethod
+    def from_thinking(thinking: str, *, role: str | None = None) -> Content:
+        """Create a Content with a single ThinkingPart."""
+        return Content(role=role, parts=[ThinkingPart(thinking=thinking)])
+
+    @staticmethod
     def from_data(data: dict[str, Any], *, role: str | None = None) -> Content:
         """Create a Content with a single DataPart."""
         return Content(role=role, parts=[DataPart(data=data)])
@@ -162,6 +185,11 @@ class Content(BaseModel):
     def text(self) -> str:
         """Concatenate all text parts."""
         return "".join(p.text for p in self.parts if isinstance(p, TextPart))
+
+    @property
+    def thinking(self) -> str:
+        """Concatenate all thinking parts."""
+        return "".join(p.thinking for p in self.parts if isinstance(p, ThinkingPart))
 
     @property
     def data(self) -> dict[str, Any] | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orxhestra"
-version = "0.0.40"
+version = "0.0.41"
 description = "Multi-Agent Orchestration Framework for Python"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Adds `ThinkingPart` to the content model system for first-class thinking/reasoning support
- Extracts thinking blocks (Anthropic `thinking` and LangChain-normalized `reasoning` types) from streaming LLM chunks and emits them as partial `AGENT_MESSAGE` events
- Renders thinking tokens in the CLI with dim italic styling, with a clean separator when transitioning to regular response text
- Filters thinking/reasoning content from `LlmResponse.text` so it doesn't leak into session history or LLM context replay
- Bumps version to 0.0.41

## Files changed
- `orxhestra/models/part.py` — `ThinkingPart` class, `Content.from_thinking()`, `Content.thinking` property
- `orxhestra/agents/llm_agent.py` — `_call_llm()` thinking extraction from chunks
- `orxhestra/models/llm_response.py` — Filter thinking from final text
- `orxhestra/cli/theme.py` — `orx.thinking` style
- `orxhestra/cli/stream.py` — CLI thinking rendering
- `orxhestra/models/__init__.py`, `orxhestra/__init__.py` — Exports

## Test plan
- [ ] Enable thinking in orx.yaml: `thinking: {type: enabled, budget_tokens: 5000}` with Anthropic provider
- [ ] Verify thinking streams in dim italic before the regular response in CLI
- [ ] Verify thinking does NOT appear in session history / LLM context replay
- [ ] Verify non-thinking models still stream normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)