### PR TITLE
Runner: add active_agent_state_key for multi-turn sub-agent flows

### DIFF
--- a/orxhestra/runner.py
+++ b/orxhestra/runner.py
@@ -39,6 +39,7 @@ from orxhestra.agents.invocation_context import InvocationContext
 from orxhestra.agents.tracing import end_agent_span, error_agent_span, start_agent_span
 from orxhestra.artifacts.base_artifact_service import BaseArtifactService
 from orxhestra.events.event import Event, EventType
+from orxhestra.events.event_actions import EventActions
 from orxhestra.models.part import Content
 from orxhestra.sessions.base_session_service import BaseSessionService
 from orxhestra.sessions.compaction import CompactionConfig, compact_session
@@ -73,6 +74,14 @@ class Runner:
     compaction_config : CompactionConfig, optional
         If set, enables automatic session compaction after each
         invocation.
+    active_agent_state_key : str, optional
+        If set, the runner persists the name of the currently-active
+        agent at ``session.state[active_agent_state_key]`` and resumes
+        from it on the next ``astream()`` call. This turns transfer-based
+        sub-agent interactions into multi-turn flows (interviews, wizards)
+        without the root agent having to re-transfer on every user turn.
+        Default ``None`` preserves today's behavior (every turn starts
+        at the root agent).
     """
 
     def __init__(
@@ -84,12 +93,14 @@ class Runner:
         artifact_service: BaseArtifactService | None = None,
         compaction_config: CompactionConfig | None = None,
         default_config: dict | None = None,
+        active_agent_state_key: str | None = None,
     ) -> None:
         self.agent = agent
         self.app_name = app_name
         self.session_service = session_service
         self.artifact_service = artifact_service
         self.compaction_config = compaction_config
+        self.active_agent_state_key = active_agent_state_key
         self._base_config = default_config or {}
 
     async def get_or_create_session(
@@ -176,16 +187,27 @@ class Runner:
         meta.setdefault("app_name", self.app_name)
         run_config["metadata"] = meta
 
+        # Pick the starting agent. Defaults to the root, but when
+        # active_agent_state_key is configured we honor a previously-persisted
+        # active-agent name so sub-agent interactions can span multiple turns.
+        starting_agent = self.agent
+        if self.active_agent_state_key:
+            active_name = (session.state or {}).get(self.active_agent_state_key)
+            if active_name and active_name != self.agent.name:
+                found = self.agent.find_agent(active_name)
+                if found is not None:
+                    starting_agent = found
+
         ctx = InvocationContext(
             session_id=session.id,
             user_id=user_id,
             app_name=self.app_name,
-            agent_name=self.agent.name,
+            agent_name=starting_agent.name,
             state=dict(session.state),
             input_content=new_message,
             session=session,
             run_config=run_config,
-            current_agent=self.agent,
+            current_agent=starting_agent,
             artifact_service=self.artifact_service,
         )
 
@@ -202,7 +224,7 @@ class Runner:
             ctx, f"Runner:{self.agent.name}", "Runner", {"input": new_message},
         )
 
-        current_agent = self.agent
+        current_agent = starting_agent
         last_text: str = ""
 
         _span_err: BaseException | None = None
@@ -225,6 +247,25 @@ class Runner:
                 target = self.agent.find_agent(transfer_target)
                 if target is None:
                     break
+
+                # When active-agent persistence is enabled, mark every resolved
+                # transfer in session.state so the next astream() resumes at the
+                # right place. A transfer back to the root clears the key.
+                if self.active_agent_state_key:
+                    new_active: str | None = (
+                        None if target is self.agent else target.name
+                    )
+                    marker_event = Event(
+                        type=EventType.AGENT_MESSAGE,
+                        author="system",
+                        session_id=session.id,
+                        invocation_id=ctx.invocation_id,
+                        content=Content(parts=[]),
+                        actions=EventActions(
+                            state_delta={self.active_agent_state_key: new_active}
+                        ),
+                    )
+                    await self.session_service.append_event(session, marker_event)
 
                 current_agent = target
                 ctx = ctx.model_copy(update={"agent_name": target.name})

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -143,6 +143,164 @@ async def test_runner_get_or_create_session():
     assert session2.id == session.id
 
 
+class TransferAgent(BaseAgent):
+    """Agent that emits a transfer_to_agent action on its single event."""
+
+    def __init__(self, name: str, target_name: str):
+        super().__init__(name=name)
+        self._target_name = target_name
+
+    async def astream(self, input, config=None, *, ctx=None):
+        ctx = self._ensure_ctx(config, ctx)
+        yield self._emit_event(
+            ctx,
+            EventType.AGENT_MESSAGE,
+            content=Content.from_text(f"transferring to {self._target_name}"),
+            actions=EventActions(transfer_to_agent=self._target_name),
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_active_agent_key_persists_on_transfer():
+    """When active_agent_state_key is set, a transfer writes the target name
+    into session.state so the next turn resumes there."""
+    svc = InMemorySessionService()
+    child = StubAgent(name="child", answer="child-reply")
+    root = TransferAgent(name="root", target_name="child")
+    root.register_sub_agent(child)
+
+    runner = Runner(
+        agent=root,
+        app_name="app",
+        session_service=svc,
+        active_agent_state_key="_active",
+    )
+
+    async for _ in runner.astream(user_id="u1", session_id="s1", new_message="go"):
+        pass
+
+    session = await svc.get_session(app_name="app", user_id="u1", session_id="s1")
+    assert session.state["_active"] == "child"
+
+
+@pytest.mark.asyncio
+async def test_runner_active_agent_key_resumes_subagent_on_next_turn():
+    """When a previous turn left a sub-agent active, the next astream() starts
+    at that sub-agent instead of the root."""
+    svc = InMemorySessionService()
+
+    # Seed the session with _active = "child" directly
+    await svc.create_session(
+        app_name="app", user_id="u1", session_id="s1", state={"_active": "child"}
+    )
+
+    child = StubAgent(name="child", answer="child-reply")
+    root = StubAgent(name="root", answer="root-reply")
+    root.register_sub_agent(child)
+
+    runner = Runner(
+        agent=root,
+        app_name="app",
+        session_service=svc,
+        active_agent_state_key="_active",
+    )
+
+    events = [
+        e async for e in runner.astream(
+            user_id="u1", session_id="s1", new_message="hi"
+        )
+    ]
+    # The sub-agent should answer, not the root.
+    agent_events = [e for e in events if e.type == EventType.AGENT_MESSAGE]
+    assert len(agent_events) == 1
+    assert agent_events[0].text == "child-reply"
+
+
+@pytest.mark.asyncio
+async def test_runner_active_agent_key_cleared_on_transfer_back_to_root():
+    """Transferring back to the root agent clears the active-agent key."""
+    svc = InMemorySessionService()
+
+    await svc.create_session(
+        app_name="app", user_id="u1", session_id="s1", state={"_active": "child"}
+    )
+
+    # Sub-agent transfers back to root.
+    child = TransferAgent(name="child", target_name="root")
+    root = StubAgent(name="root", answer="back-at-root")
+    root.register_sub_agent(child)
+
+    runner = Runner(
+        agent=root,
+        app_name="app",
+        session_service=svc,
+        active_agent_state_key="_active",
+    )
+
+    async for _ in runner.astream(user_id="u1", session_id="s1", new_message="done"):
+        pass
+
+    session = await svc.get_session(app_name="app", user_id="u1", session_id="s1")
+    assert session.state["_active"] is None
+
+
+@pytest.mark.asyncio
+async def test_runner_active_agent_key_none_default_unchanged():
+    """Without active_agent_state_key, behavior is unchanged: every turn starts at root."""
+    svc = InMemorySessionService()
+
+    # Pretend a previous turn marked a sub-agent active via state. With the
+    # feature OFF (default), this should be ignored.
+    await svc.create_session(
+        app_name="app", user_id="u1", session_id="s1", state={"_active": "child"}
+    )
+
+    child = StubAgent(name="child", answer="child-reply")
+    root = StubAgent(name="root", answer="root-reply")
+    root.register_sub_agent(child)
+
+    runner = Runner(agent=root, app_name="app", session_service=svc)  # no key
+
+    events = [
+        e async for e in runner.astream(
+            user_id="u1", session_id="s1", new_message="hi"
+        )
+    ]
+    agent_events = [e for e in events if e.type == EventType.AGENT_MESSAGE]
+    assert len(agent_events) == 1
+    assert agent_events[0].text == "root-reply"
+
+
+@pytest.mark.asyncio
+async def test_runner_active_agent_key_ignored_when_unknown_agent():
+    """If the persisted name isn't in the tree, fall back to root (don't crash)."""
+    svc = InMemorySessionService()
+
+    await svc.create_session(
+        app_name="app",
+        user_id="u1",
+        session_id="s1",
+        state={"_active": "deleted-agent"},
+    )
+
+    root = StubAgent(name="root", answer="root-reply")
+    runner = Runner(
+        agent=root,
+        app_name="app",
+        session_service=svc,
+        active_agent_state_key="_active",
+    )
+
+    events = [
+        e async for e in runner.astream(
+            user_id="u1", session_id="s1", new_message="hi"
+        )
+    ]
+    agent_events = [e for e in events if e.type == EventType.AGENT_MESSAGE]
+    assert len(agent_events) == 1
+    assert agent_events[0].text == "root-reply"
+
+
 @pytest.mark.asyncio
 async def test_runner_passes_config_to_agent():
     """Config dict reaches the agent context via run_config."""


### PR DESCRIPTION
## Summary

Adds an opt-in mechanism so sub-agent interactions can **span multiple user turns** without the root agent having to re-transfer on every turn.

### Motivation

Today `Runner.astream()` hardcodes `current_agent = self.agent` at the top of every call. For single-shot transfers that's fine, but interview/wizard/guided-flow sub-agents break: the specialist asks a clarifying question, the user answers, and the next user message arrives back at the root — which then has to recognise the in-progress interview and re-transfer. In practice the LLM at the root emits its own prose *before* calling `transfer_to_agent`, so users see two responses per turn. Every app building this pattern has to hack around it in prompts. The persistence belongs in the Runner.

Concrete example — an interview-style subagent that gathers structured data from the user over several turns before saving:

```python
from orxhestra import Runner, LlmAgent
from orxhestra.tools.transfer_tool import make_transfer_tool

interviewer = LlmAgent(name="interviewer", ...)
root = LlmAgent(
    name="router",
    tools=[make_transfer_tool([interviewer])],
    ...
)
root.register_sub_agent(interviewer)

# Without active_agent_state_key: every user answer lands back at `root`,
# which has to re-transfer (often emitting prose first → duplicated replies).
# With active_agent_state_key set: the turn after a transfer resumes at
# `interviewer` directly, and only returns to `root` when the interviewer
# transfers back explicitly.
runner = Runner(
    agent=root,
    app_name="my-app",
    session_service=service,
    active_agent_state_key="_active_agent_name",
)
```

Workaround prior to this PR: subclass `Runner`, reimplement `astream`, and hand-roll the state persistence. Works, but every app needs to duplicate that code — and reimplementing `astream` means catching up to any upstream changes (tracing, compaction, config merging, etc.).

### Change

- **New constructor param** `active_agent_state_key: str | None = None`. Default preserves existing root-first behavior exactly; opt-in by passing a key.
- When set, `astream()` reads `session.state[active_agent_state_key]` and starts from that agent if it resolves via `find_agent`. Unknown names fall back to root.
- Every resolved transfer appends a `state_delta` event persisting the new active-agent name. Transfer back to root stores `None`, so the key clears cleanly.

### Tests

Added five tests in `tests/test_runner.py` covering:
- Transfer persists the target name into `session.state`.
- Next turn resumes at the sub-agent when the key is present.
- Transfer back to root clears the key.
- Feature off (default) = existing root-first behavior unchanged.
- Stale/unknown agent names in state fall back to root without crashing.

All 12 runner tests pass (`uv run pytest tests/test_runner.py`).

### Non-goals / out of scope

- Doesn't change transfer-tool semantics or `make_transfer_tool`.
- Doesn't touch `LlmAgent`, `LoopAgent`, `SequentialAgent`.
- Doesn't introduce any state keys unless the app opts in.

Happy to iterate on naming (`active_agent_state_key` vs `resumable_state_key` vs anything else) or the persistence shape (marker event vs in-memory only) — this was the least invasive design I could see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)