### PR TITLE
v0.1.7 — Ctrl+J inserts newline + responsive REPL under heavy output

### DIFF
--- a/orxhestra/__init__.py
+++ b/orxhestra/__init__.py
@@ -47,7 +47,7 @@ Identity / trust / attestation (opt-in, requires ``orxhestra[auth]``)::
     )
 """
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 from orxhestra.agents import (
     AgentConfig,

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -345,8 +345,14 @@ def orx_repl(
         #   - Kitty CSI u format: "\x1b[13;<mod>u" for modified Enter.
         # Universal fallback: type "\" then press Enter — the trailing
         # backslash is replaced with a newline (popular in shells).
+        # Note: do NOT include key.ctrl here. Some terminals (including
+        # VS Code's integrated terminal in certain configs) send "\n"
+        # for plain Enter; pyink 1.1.16+ disambiguates that from \r by
+        # setting key.ctrl, but treating ctrl+return as newline-insert
+        # would then break plain Enter submit. Use "\Enter" as the
+        # universal newline shortcut instead.
         is_modified_enter = (
-            (key.return_key and (key.shift or key.meta or key.ctrl))
+            (key.return_key and (key.shift or key.meta))
             or ch in ("\x1b\r", "\x1b\n", "\x1bOM")
             or (ch and ch.startswith("\x1b[13;") and ch.endswith("u"))
         )

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -248,25 +248,6 @@ def orx_repl(
     total_opts = len(sel_options) + (1 if sel_show_type.current else 0)
 
     def on_key(ch, key):
-        # Debug helper: ORX_KEY_DEBUG=1 surfaces every keypress as a
-        # muted history line so we can see exactly what bytes the
-        # terminal sends for whatever shortcut we're trying to bind.
-        import os as _os
-        if _os.environ.get("ORX_KEY_DEBUG"):
-            flags = [
-                name for name in (
-                    "shift", "ctrl", "meta", "super_key", "tab",
-                    "return_key", "escape", "backspace", "delete",
-                    "up_arrow", "down_arrow", "left_arrow", "right_arrow",
-                    "home", "end",
-                ) if getattr(key, name, False)
-            ]
-            ch_repr = repr(ch) if ch else "''"
-            line = f"  key: ch={ch_repr} flags={'|'.join(flags) or '-'}"
-            set_history(lambda h, ln=line: [
-                *h, {"type": "plain", "ansi": ln, "color": _MUTED, "dim": True},
-            ])
-
         # ── Free-text input mode (answering human_input) ──
         if freetext:
             if key.return_key:

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -83,16 +83,6 @@ def _history_item(item, _index=0):
             margin_top=1,
             margin_bottom=1,
         )
-    if t == "user_continuation":
-        # Queued message that was drained mid-session: render as a
-        # follow-up attached to the previous response (no top margin),
-        # so a chain of turns reads as one continuous flow.
-        return Box(
-            Text("\u276f ", color=_ACCENT),
-            Text(item["text"], bold=True),
-            flex_direction="row",
-            margin_bottom=1,
-        )
     if t == "response":
         # Prepend bullet directly to avoid flex-row spacing issues
         # where ANSI codes can consume the space between ● and text.
@@ -742,7 +732,7 @@ def _dispatch_agent(message, state, writer, set_history,
                 if drained:
                     for line in drained:
                         set_history(lambda h, m=line: [
-                            *h, {"type": "user_continuation", "text": m},
+                            *h, {"type": "user", "text": m},
                         ])
                     current = drained[-1]
                 else:

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -335,20 +335,40 @@ def orx_repl(
                 ac_idx.current = 0
             return
 
-        # Multi-line newline insert. Most terminals send the same byte
-        # for Enter and Shift+Enter, so we accept Shift+Enter (when the
-        # terminal supports the kitty keyboard protocol) AND
-        # Alt/Option+Enter (universal: terminals send "\x1b\r") as the
-        # newline binding.
-        is_newline_insert = (
-            (key.return_key and key.shift)
-            or ch == "\x1b\r"
-            or ch == "\x1b\n"
+        # Multi-line newline insert. Different terminals send wildly
+        # different bytes for "modified Enter":
+        #   - kitty/ghostty (with kitty keyboard protocol): key.shift
+        #     gets set on the parsed Enter.
+        #   - iTerm2 with "Send Esc+" or Terminal.app with "Use Option
+        #     as Meta key": Alt/Option+Enter sends "\x1b\r".
+        #   - Some emit "\x1bOM" (xterm SS3 enter).
+        #   - Kitty CSI u format: "\x1b[13;<mod>u" for modified Enter.
+        # Universal fallback: type "\" then press Enter — the trailing
+        # backslash is replaced with a newline (popular in shells).
+        is_modified_enter = (
+            (key.return_key and (key.shift or key.meta or key.ctrl))
+            or ch in ("\x1b\r", "\x1b\n", "\x1bOM")
+            or (ch and ch.startswith("\x1b[13;") and ch.endswith("u"))
         )
-        if is_newline_insert:
+        backslash_enter = (
+            key.return_key
+            and not (key.shift or key.meta or key.ctrl)
+            and cursor > 0
+            and cursor <= len(buf)
+            and buf[cursor - 1] == "\\"
+            and not suggestions
+        )
+        if is_modified_enter:
             pos = cursor
             set_buf(lambda t, p=pos: t[:p] + "\n" + t[p:])
             set_cursor(lambda c: c + 1)
+            ac_idx.current = 0
+            return
+        if backslash_enter:
+            # Replace the trailing "\" with a newline. Cursor stays at
+            # the same offset (was after "\", now after "\n").
+            pos = cursor
+            set_buf(lambda t, p=pos: t[:p - 1] + "\n" + t[p:])
             ac_idx.current = 0
             return
 

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -248,6 +248,25 @@ def orx_repl(
     total_opts = len(sel_options) + (1 if sel_show_type.current else 0)
 
     def on_key(ch, key):
+        # Debug helper: ORX_KEY_DEBUG=1 surfaces every keypress as a
+        # muted history line so we can see exactly what bytes the
+        # terminal sends for whatever shortcut we're trying to bind.
+        import os as _os
+        if _os.environ.get("ORX_KEY_DEBUG"):
+            flags = [
+                name for name in (
+                    "shift", "ctrl", "meta", "super_key", "tab",
+                    "return_key", "escape", "backspace", "delete",
+                    "up_arrow", "down_arrow", "left_arrow", "right_arrow",
+                    "home", "end",
+                ) if getattr(key, name, False)
+            ]
+            ch_repr = repr(ch) if ch else "''"
+            line = f"  key: ch={ch_repr} flags={'|'.join(flags) or '-'}"
+            set_history(lambda h, ln=line: [
+                *h, {"type": "plain", "ansi": ln, "color": _MUTED, "dim": True},
+            ])
+
         # ── Free-text input mode (answering human_input) ──
         if freetext:
             if key.return_key:

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -438,7 +438,7 @@ def orx_repl(
                 cur_line, cur_col = len(buf_lines) - 1, len(buf_lines[-1])
             if cur_line > 0:
                 target_col = min(cur_col, len(buf_lines[cur_line - 1]))
-                offset = sum(len(l) + 1 for l in buf_lines[:cur_line - 1]) + target_col
+                offset = sum(len(ln) + 1 for ln in buf_lines[:cur_line - 1]) + target_col
                 set_cursor(offset)
                 return
         if key.down_arrow and "\n" in buf:
@@ -454,7 +454,7 @@ def orx_repl(
                 cur_line, cur_col = len(buf_lines) - 1, len(buf_lines[-1])
             if cur_line < len(buf_lines) - 1:
                 target_col = min(cur_col, len(buf_lines[cur_line + 1]))
-                offset = sum(len(l) + 1 for l in buf_lines[:cur_line + 1]) + target_col
+                offset = sum(len(ln) + 1 for ln in buf_lines[:cur_line + 1]) + target_col
                 set_cursor(offset)
                 return
 

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -335,6 +335,23 @@ def orx_repl(
                 ac_idx.current = 0
             return
 
+        # Multi-line newline insert. Most terminals send the same byte
+        # for Enter and Shift+Enter, so we accept Shift+Enter (when the
+        # terminal supports the kitty keyboard protocol) AND
+        # Alt/Option+Enter (universal: terminals send "\x1b\r") as the
+        # newline binding.
+        is_newline_insert = (
+            (key.return_key and key.shift)
+            or ch == "\x1b\r"
+            or ch == "\x1b\n"
+        )
+        if is_newline_insert:
+            pos = cursor
+            set_buf(lambda t, p=pos: t[:p] + "\n" + t[p:])
+            set_cursor(lambda c: c + 1)
+            ac_idx.current = 0
+            return
+
         # Enter.
         if key.return_key:
             if suggestions:
@@ -391,6 +408,42 @@ def orx_repl(
             ac_idx.current = min(len(suggestions) - 1, ac_idx.current + 1)
             return
 
+        # Multi-line cursor navigation. When the buffer spans multiple
+        # lines, up/down move between lines first; only fall through to
+        # history nav when the cursor is on the top/bottom line.
+        if key.up_arrow and "\n" in buf:
+            buf_lines = buf.split("\n")
+            remaining = cursor
+            cur_line, cur_col = 0, 0
+            for i, line in enumerate(buf_lines):
+                if remaining <= len(line):
+                    cur_line, cur_col = i, remaining
+                    break
+                remaining -= len(line) + 1
+            else:
+                cur_line, cur_col = len(buf_lines) - 1, len(buf_lines[-1])
+            if cur_line > 0:
+                target_col = min(cur_col, len(buf_lines[cur_line - 1]))
+                offset = sum(len(l) + 1 for l in buf_lines[:cur_line - 1]) + target_col
+                set_cursor(offset)
+                return
+        if key.down_arrow and "\n" in buf:
+            buf_lines = buf.split("\n")
+            remaining = cursor
+            cur_line, cur_col = 0, 0
+            for i, line in enumerate(buf_lines):
+                if remaining <= len(line):
+                    cur_line, cur_col = i, remaining
+                    break
+                remaining -= len(line) + 1
+            else:
+                cur_line, cur_col = len(buf_lines) - 1, len(buf_lines[-1])
+            if cur_line < len(buf_lines) - 1:
+                target_col = min(cur_col, len(buf_lines[cur_line + 1]))
+                offset = sum(len(l) + 1 for l in buf_lines[:cur_line + 1]) + target_col
+                set_cursor(offset)
+                return
+
         # History.
         if key.up_arrow:
             h = cmd_hist.current
@@ -423,10 +476,20 @@ def orx_repl(
             set_cursor(lambda c: min(len(buf), c + 1))
             return
         if key.home:
-            set_cursor(0)
+            # Jump to start of current line (or buffer if single-line).
+            if "\n" in buf:
+                line_start = buf.rfind("\n", 0, cursor) + 1
+                set_cursor(line_start)
+            else:
+                set_cursor(0)
             return
         if key.end:
-            set_cursor(len(buf))
+            # Jump to end of current line (or buffer if single-line).
+            if "\n" in buf:
+                next_nl = buf.find("\n", cursor)
+                set_cursor(len(buf) if next_nl == -1 else next_nl)
+            else:
+                set_cursor(len(buf))
             return
 
         # Backspace.
@@ -491,22 +554,49 @@ def orx_repl(
             show_type_option=sel_show_type.current,
         ))
 
-    # Input area with border + cursor.
-    before = buf[:cursor]
-    char_at = buf[cursor] if cursor < len(buf) else " "
-    after = buf[cursor + 1:] if cursor < len(buf) else ""
-
+    # Input area with border + cursor. For multi-line buffers, render
+    # one row per line; the first row carries the \u276f prompt, the rest
+    # use a blank-aligned indent so the columns line up.
     prompt_label = "?" if freetext else "\u276f"
+
+    lines = buf.split("\n") if buf else [""]
+    # Map cursor offset \u2192 (line_idx, col_idx).
+    remaining = cursor
+    cursor_line = 0
+    cursor_col = 0
+    for i, line in enumerate(lines):
+        if remaining <= len(line):
+            cursor_line, cursor_col = i, remaining
+            break
+        remaining -= len(line) + 1  # +1 for the \n
+    else:
+        cursor_line = len(lines) - 1
+        cursor_col = len(lines[-1])
+
+    rows = []
+    for i, line in enumerate(lines):
+        prompt = f"  {prompt_label} " if i == 0 else "    "
+        if i == cursor_line:
+            before = line[:cursor_col]
+            char_at = line[cursor_col] if cursor_col < len(line) else " "
+            after = line[cursor_col + 1:] if cursor_col < len(line) else ""
+            rows.append(Box(
+                Text(prompt, color=_ACCENT, bold=True),
+                Text(before, bold=True),
+                Text(char_at, bold=True, inverse=True),
+                Text(after, bold=True),
+                flex_direction="row",
+            ))
+        else:
+            rows.append(Box(
+                Text(prompt, color=_ACCENT, bold=True),
+                Text(line, bold=True),
+                flex_direction="row",
+            ))
 
     input_children = [
         Text(_SEPARATOR, color=_MUTED, dim=True),
-        Box(
-            Text(f"  {prompt_label} ", color=_ACCENT, bold=True),
-            Text(before, bold=True),
-            Text(char_at, bold=True, inverse=True),
-            Text(after, bold=True),
-            flex_direction="row",
-        ),
+        Box(*rows, flex_direction="column"),
     ]
     if suggestions and not sel_active and not freetext:
         input_children.append(_autocomplete_menu(

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -335,22 +335,10 @@ def orx_repl(
                 ac_idx.current = 0
             return
 
-        # Multi-line newline insert. Different terminals send wildly
-        # different bytes for "modified Enter":
-        #   - kitty/ghostty (with kitty keyboard protocol): key.shift
-        #     gets set on the parsed Enter.
-        #   - iTerm2 with "Send Esc+" or Terminal.app with "Use Option
-        #     as Meta key": Alt/Option+Enter sends "\x1b\r".
-        #   - Some emit "\x1bOM" (xterm SS3 enter).
-        #   - Kitty CSI u format: "\x1b[13;<mod>u" for modified Enter.
-        # Universal fallback: type "\" then press Enter — the trailing
-        # backslash is replaced with a newline (popular in shells).
-        # Note: do NOT include key.ctrl here. Some terminals (including
-        # VS Code's integrated terminal in certain configs) send "\n"
-        # for plain Enter; pyink 1.1.16+ disambiguates that from \r by
-        # setting key.ctrl, but treating ctrl+return as newline-insert
-        # would then break plain Enter submit. Use "\Enter" as the
-        # universal newline shortcut instead.
+        # Newline insert: accept whatever modifier+Enter sequence the
+        # terminal sends. Ctrl is intentionally NOT a trigger — some
+        # terminals send "\n" for plain Enter and pyink can't always
+        # distinguish that from Ctrl+J at the byte level.
         is_modified_enter = (
             (key.return_key and (key.shift or key.meta))
             or ch in ("\x1b\r", "\x1b\n", "\x1bOM")

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -6,6 +6,7 @@ import asyncio
 import re as _re
 import shutil as _shutil
 import threading
+from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from pyink import Box, Static, Text, component, render
@@ -80,6 +81,16 @@ def _history_item(item, _index=0):
             Text(item["text"], bold=True),
             flex_direction="row",
             margin_top=1,
+            margin_bottom=1,
+        )
+    if t == "user_continuation":
+        # Queued message that was drained mid-session: render as a
+        # follow-up attached to the previous response (no top margin),
+        # so a chain of turns reads as one continuous flow.
+        return Box(
+            Text("\u276f ", color=_ACCENT),
+            Text(item["text"], bold=True),
+            flex_direction="row",
             margin_bottom=1,
         )
     if t == "response":
@@ -180,6 +191,21 @@ def orx_repl(
     running = use_ref(False)
     writer_ref = use_ref(None)
     ac_idx = use_ref(0)
+
+    # Pending message queue: messages typed while the agent is running
+    # are appended here and drained in FIFO order by _dispatch_agent
+    # once the current turn completes. Queued messages render as
+    # floating user lines in the dynamic area (between stream and
+    # input) — NOT in scrollback — so the in-flight response's final
+    # chunk is never committed after a queued user line. When the
+    # worker dequeues a message it pushes the user line into history
+    # at the correct moment.
+    pending_msgs = use_ref(deque())
+    queue_lock = use_ref(threading.Lock())
+    # Snapshot of pending_msgs for rendering. Lives in state (not ref)
+    # so mutations trigger a re-render. Updated under queue_lock so
+    # the snapshot and the deque can never disagree on order.
+    pending_view, set_pending_view = use_state(())
 
     app = use_app()
 
@@ -293,7 +319,13 @@ def orx_repl(
 
         if key.ctrl and ch == "c":
             if running.current:
-                running.current = False
+                with queue_lock.current:
+                    pending_msgs.current.clear()
+                    set_pending_view(())
+                    running.current = False
+                w = writer_ref.current
+                if w is not None and hasattr(w, "cancel_live"):
+                    w.cancel_live()
                 set_phase("idle")
                 set_spinner_text("")
                 set_stream("")
@@ -335,18 +367,30 @@ def orx_repl(
                     orx_path_ref.current, workspace_ref.current,
                     set_history, app,
                 )
-            elif not running.current:
+            else:
+                # Atomically check running state and either dispatch
+                # immediately or enqueue. Same lock the worker uses, so
+                # the producer never races with the consumer's drain
+                # path. Queued messages render in the floating dynamic
+                # area (via pending_view) — they get pushed into
+                # scrollback only when the worker actually dequeues
+                # them, so the previous turn's response is always fully
+                # committed before the next user line lands in history.
+                with queue_lock.current:
+                    if running.current:
+                        pending_msgs.current.append(msg)
+                        snapshot = tuple(pending_msgs.current)
+                        set_pending_view(snapshot)
+                        return
+                    running.current = True
+                set_history(lambda h, m=msg: [
+                    *h, {"type": "user", "text": m},
+                ])
                 _dispatch_agent(
                     msg, state_ref.current, writer_ref.current,
                     set_history, set_phase, running,
+                    pending_msgs, queue_lock, set_pending_view,
                 )
-            else:
-                set_history(lambda h: [
-                    *h,
-                    {"type": "plain",
-                     "ansi": "  Agent is still running.",
-                     "color": _MUTED},
-                ])
             return
 
         # Arrow keys for autocomplete.
@@ -434,6 +478,19 @@ def orx_repl(
             Text(stream_buf),
             flex_direction="row",
         ))
+
+    # Floating queued user messages — typed while the agent is
+    # running. They live here (not in scrollback) until the worker
+    # drains them, so the in-flight response is always committed to
+    # history before any queued user-line lands there.
+    if pending_view:
+        for queued in pending_view:
+            dynamic.append(Box(
+                Text("❯ ", color=_ACCENT),
+                Text(queued, bold=True),
+                flex_direction="row",
+                margin_top=1,
+            ))
 
     # Selector (approval or human_input).
     if sel_active:
@@ -607,9 +664,21 @@ def _dispatch_slash(text, state, writer, orx_path, workspace,
 
 
 def _dispatch_agent(message, state, writer, set_history,
-                    set_phase, running_ref):
-    set_history(lambda h: [*h, {"type": "user", "text": message}])
-    running_ref.current = True
+                    set_phase, running_ref,
+                    pending_msgs_ref, queue_lock_ref, set_pending_view):
+    """Spawn the worker thread that drains the user-message queue.
+
+    The caller has already pushed the user-line for ``message`` to
+    history and flipped ``running_ref.current`` to True under
+    ``queue_lock_ref.current``. The worker runs the turn, then loops:
+    pop the next pending message under the lock, push *its* user-line
+    to history (so it lands AFTER the prior turn's response has been
+    committed by the live handle's ``stop``), and run it. When the
+    queue is empty the worker flips ``running_ref.current`` to False
+    under the same lock — so the Enter handler's check-and-enqueue is
+    race-free. The lock is only held for O(1) work, never across
+    ``stream_response``.
+    """
 
     def run():
         try:
@@ -618,40 +687,79 @@ def _dispatch_agent(message, state, writer, set_history,
             set_history(lambda h: [
                 *h, {"type": "plain", "ansi": "Error: rich required."},
             ])
-            running_ref.current = False
+            with queue_lock_ref.current:
+                pending_msgs_ref.current.clear()
+                set_pending_view(())
+                running_ref.current = False
             return
 
         from orxhestra.cli.stream import stream_response
 
         loop = asyncio.new_event_loop()
+        current = message
         try:
-            state.auto_approve = loop.run_until_complete(stream_response(
-                state.runner, state.session_id, message,
-                writer, Markdown,
-                todo_list=state.todo_list,
-                auto_approve=state.auto_approve,
-            ))
-            state.turn_count += 1
-        except Exception as exc:
-            err_msg = str(exc)
-            # Truncate long error messages (e.g. API quota errors)
-            if len(err_msg) > 200:
-                err_msg = err_msg[:200] + "..."
-            set_history(lambda h: [
-                *h, {"type": "plain", "ansi": f"Error: {err_msg}", "color": "red"},
-            ])
+            while current is not None:
+                try:
+                    state.auto_approve = loop.run_until_complete(stream_response(
+                        state.runner, state.session_id, current,
+                        writer, Markdown,
+                        todo_list=state.todo_list,
+                        auto_approve=state.auto_approve,
+                    ))
+                    state.turn_count += 1
+                except Exception as exc:
+                    err_msg = str(exc)
+                    if len(err_msg) > 200:
+                        err_msg = err_msg[:200] + "..."
+                    set_history(lambda h, e=err_msg: [
+                        *h, {"type": "plain",
+                             "ansi": f"Error: {e}", "color": "red"},
+                    ])
+                    # Drop the queue on error so we don't loop on
+                    # whatever caused the failure.
+                    with queue_lock_ref.current:
+                        pending_msgs_ref.current.clear()
+                        set_pending_view(())
+                        running_ref.current = False
+                    current = None
+                    break
+
+                # Atomically: either drain the queue and stay running,
+                # or flip running=False under the same lock so the
+                # Enter handler's check-and-enqueue is race-free.
+                # Drain semantics: messages typed while the previous
+                # turn was streaming all show in history as user-lines,
+                # but only the LAST one triggers a new completion. The
+                # intermediate ones are treated as superseded thoughts.
+                with queue_lock_ref.current:
+                    if pending_msgs_ref.current:
+                        drained = list(pending_msgs_ref.current)
+                        pending_msgs_ref.current.clear()
+                        set_pending_view(())
+                    else:
+                        running_ref.current = False
+                        drained = None
+                if drained:
+                    for line in drained:
+                        set_history(lambda h, m=line: [
+                            *h, {"type": "user_continuation", "text": m},
+                        ])
+                    current = drained[-1]
+                else:
+                    current = None
         finally:
-            running_ref.current = False
             set_phase("idle")
-        # Cancel pending tasks before closing to avoid
-        # "Task was destroyed but it is pending" warnings.
-        for task in asyncio.all_tasks(loop):
-            task.cancel()
-        try:
-            pending = asyncio.all_tasks(loop)
-            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-        except Exception:
-            pass
-        loop.close()
+            # Cancel pending tasks before closing to avoid
+            # "Task was destroyed but it is pending" warnings.
+            for task in asyncio.all_tasks(loop):
+                task.cancel()
+            try:
+                leftover = asyncio.all_tasks(loop)
+                loop.run_until_complete(
+                    asyncio.gather(*leftover, return_exceptions=True),
+                )
+            except Exception:
+                pass
+            loop.close()
 
     threading.Thread(target=run, daemon=True).start()

--- a/orxhestra/cli/stream.py
+++ b/orxhestra/cli/stream.py
@@ -117,7 +117,7 @@ class _StreamState:
         if self.in_stream:
             if self.live_handle is not None:
                 if self.buffer:
-                    self.live_handle.update(markdown_cls(self.buffer))
+                    self.live_handle.update_text(self.buffer, markdown_cls)
                 writer.stop_live(self.live_handle, keep=True)
                 self.live_handle = None
             elif self.buffer:
@@ -271,9 +271,7 @@ async def stream_response(
                 if not s.in_stream:
                     s.in_stream = True
                     s.live_handle = writer.start_live()
-                    s.live_handle.update(markdown_cls(s.buffer))
-                else:
-                    s.live_handle.update(markdown_cls(s.buffer))
+                s.live_handle.update_text(s.buffer, markdown_cls)
                 continue
 
             if event.has_tool_calls:

--- a/orxhestra/cli/writer.py
+++ b/orxhestra/cli/writer.py
@@ -38,12 +38,17 @@ class LiveHandle(Protocol):
     Attributes
     ----------
     update : callable
-        Replace the live region content with a new renderable.
+        Replace the live region content with a new Rich renderable.
+    update_text : callable
+        Submit the cumulative buffer text + markdown class. Preferred
+        for streaming so the implementation can window/throttle/spill
+        without the caller knowing.
     stop : callable
         End the live region, optionally freezing content to history.
     """
 
     def update(self, renderable: Any) -> None: ...
+    def update_text(self, text: str, markdown_cls: type) -> None: ...
     def stop(self, *, keep: bool = True) -> None: ...
 
 
@@ -119,6 +124,43 @@ class Writer(Protocol):
         ...
 
 
+# Bounds for the live streaming region. Keep per-frame layout work
+# constant regardless of total response length. See _StreamRenderer.
+_STREAM_TAIL_LINES = 80
+_SPILL_THRESHOLD = 400
+_MAX_LINE_CHARS = 2000
+_RENDER_INTERVAL = 1.0 / 12
+
+
+def _soft_wrap_long_lines(text: str, max_chars: int = _MAX_LINE_CHARS) -> str:
+    """Break pathologically long single lines (e.g. minified JSON).
+
+    Yoga layout cost grows with the longest line; uncapped lines can
+    starve the pyink render loop. Splits at the last whitespace inside
+    the chunk when possible, falls back to a hard cut otherwise.
+    """
+    out: list[str] = []
+    for line in text.split("\n"):
+        if len(line) <= max_chars:
+            out.append(line)
+            continue
+        i = 0
+        while i < len(line):
+            end = i + max_chars
+            if end >= len(line):
+                out.append(line[i:])
+                break
+            chunk = line[i:end]
+            ws = chunk.rfind(" ")
+            if ws > max_chars // 2:
+                out.append(chunk[:ws])
+                i += ws + 1
+            else:
+                out.append(chunk)
+                i = end
+    return "\n".join(out)
+
+
 def rich_to_ansi(console: Console, *args: Any, **kwargs: Any) -> str:
     """Render Rich content to a raw ANSI string.
 
@@ -189,6 +231,11 @@ class _ConsoleLive:
         """Replace the live display content."""
         if self._live:
             self._live.update(renderable)
+
+    def update_text(self, text: str, markdown_cls: type) -> None:
+        """Replace the live content with ``markdown_cls(text)``."""
+        if self._live:
+            self._live.update(markdown_cls(text))
 
     def stop(self, *, keep: bool = True) -> None:
         """Stop the live display."""
@@ -299,15 +346,150 @@ class _InkSpinnerHandle:
         self._set_spinner_text("")
 
 
+class _StreamRenderer:
+    """Background thread converting markdown to ANSI off the worker.
+
+    Keeps the agent worker thread free of Rich rendering cost. Holds a
+    single-slot mailbox: the producer overwrites the latest
+    ``(text, markdown_cls)`` and notifies; the scheduler wakes up to
+    every ``_RENDER_INTERVAL`` seconds, takes the slot, converts, and
+    pushes to pyink state.
+
+    Spill-to-history: when accumulated text exceeds ``_SPILL_THRESHOLD``
+    lines, older content is frozen as immutable history items and
+    dropped from the live tail. This bounds per-frame layout work so the
+    pyink input handler (including Ctrl+C) is never starved.
+
+    Lock discipline: the mailbox lock is only held for O(1) slot
+    read/write — never around Rich conversion or state setters — so
+    the producer never blocks behind the renderer.
+    """
+
+    def __init__(
+        self,
+        set_stream: Callable,
+        set_history: Callable,
+        console: Console,
+    ) -> None:
+        import threading
+
+        self._set_stream = set_stream
+        self._set_history = set_history
+        self._console = console
+        self._cond = threading.Condition()
+        self._slot: tuple[str, type] | None = None
+        self._stopped = False
+        self._spilled_lines = 0
+        self._last_text = ""
+        self._last_markdown_cls: type | None = None
+        self._bullet_emitted = False
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def submit(self, text: str, markdown_cls: type) -> None:
+        """Producer: store latest text + markdown class; wake scheduler."""
+        with self._cond:
+            self._slot = (text, markdown_cls)
+            self._cond.notify()
+
+    def _run(self) -> None:
+        import time
+
+        while True:
+            with self._cond:
+                while self._slot is None and not self._stopped:
+                    self._cond.wait(timeout=_RENDER_INTERVAL)
+                if self._stopped and self._slot is None:
+                    return
+                slot = self._slot
+                self._slot = None
+                stopped_now = self._stopped
+
+            if slot is None:
+                continue
+            text, markdown_cls = slot
+            self._last_text = text
+            self._last_markdown_cls = markdown_cls
+
+            # Always run spill (updates _spilled_lines, may push to
+            # history) so stop()'s final flush stays bounded; but skip
+            # set_stream when we're already stopping — the worker is
+            # about to push the final tail to scrollback and clear the
+            # dynamic region in one batch, and any late set_stream
+            # would cause a flicker between the two frames.
+            visible = self._maybe_spill(text)
+            if not stopped_now:
+                try:
+                    wrapped = _soft_wrap_long_lines(visible)
+                    ansi = rich_to_ansi(self._console, markdown_cls(wrapped))
+                    self._set_stream(ansi)
+                except Exception:
+                    pass
+
+            if stopped_now:
+                return
+            time.sleep(_RENDER_INTERVAL)
+
+    def _maybe_spill(self, text: str) -> str:
+        """Freeze older content to history once the buffer is too large."""
+        all_lines = text.split("\n")
+        unspilled = all_lines[self._spilled_lines:]
+        if len(unspilled) <= _SPILL_THRESHOLD:
+            return "\n".join(unspilled)
+
+        keep = unspilled[-_STREAM_TAIL_LINES:]
+        spill = unspilled[:-_STREAM_TAIL_LINES]
+        spill_text = "\n".join(spill)
+        if self._last_markdown_cls is not None and spill_text.strip():
+            try:
+                wrapped = _soft_wrap_long_lines(spill_text)
+                ansi = rich_to_ansi(
+                    self._console, self._last_markdown_cls(wrapped),
+                )
+                if ansi:
+                    item_type = "response" if not self._bullet_emitted else "rich"
+                    self._set_history(
+                        lambda h, a=ansi, t=item_type: [
+                            *h, {"type": t, "ansi": a},
+                        ],
+                    )
+                    self._bullet_emitted = True
+            except Exception:
+                pass
+        self._spilled_lines += len(spill)
+        return "\n".join(keep)
+
+    def stop(self, *, keep: bool = True) -> tuple[str | None, str]:
+        """Stop the scheduler and return the final tail ANSI + item type."""
+        with self._cond:
+            self._stopped = True
+            self._cond.notify_all()
+        self._thread.join(timeout=0.5)
+
+        item_type = "response" if not self._bullet_emitted else "rich"
+        if not keep or self._last_markdown_cls is None:
+            return None, item_type
+        all_lines = self._last_text.split("\n")
+        tail_text = "\n".join(all_lines[self._spilled_lines:])
+        if not tail_text.strip():
+            return None, item_type
+        try:
+            wrapped = _soft_wrap_long_lines(tail_text)
+            return (
+                rich_to_ansi(self._console, self._last_markdown_cls(wrapped)),
+                item_type,
+            )
+        except Exception:
+            return None, item_type
+
+
 class _InkLiveHandle:
     """Live-updating region backed by pyink state.
 
-    Renders Rich content to ANSI and pushes it into the stream
-    buffer. Throttled to ``_MIN_INTERVAL`` to avoid excessive
-    re-renders during fast token streaming.
+    Delegates Rich→ANSI conversion to a background ``_StreamRenderer``
+    thread so the agent worker is never blocked by rendering, and
+    bounds per-frame layout work via spill-to-history.
     """
-
-    _MIN_INTERVAL = 1.0 / 12
 
     def __init__(
         self,
@@ -320,42 +502,55 @@ class _InkLiveHandle:
         self._set_phase = set_phase
         self._set_history = set_history
         self._console = console
-        self._last_renderable: Any = None
-        self._last_update = 0.0
+        self._renderer = _StreamRenderer(set_stream, set_history, console)
+        self._stopped = False
 
     def update(self, renderable: Any) -> None:
-        """Replace the stream content with a re-rendered *renderable*.
+        """Convert and push immediately. Used by non-streaming callers.
 
-        Throttled to ~12 FPS so pyink can keep up with fast tokens.
+        Streaming callers should prefer :meth:`update_text`.
         """
-        import time
-
-        self._last_renderable = renderable
-        now = time.monotonic()
-        if now - self._last_update < self._MIN_INTERVAL:
+        if self._stopped:
             return
-        self._last_update = now
-        ansi = rich_to_ansi(self._console, renderable)
-        self._set_stream(ansi)
+        try:
+            ansi = rich_to_ansi(self._console, renderable)
+            self._set_stream(ansi)
+        except Exception:
+            pass
+
+    def update_text(self, text: str, markdown_cls: type) -> None:
+        """Submit raw text + markdown class to the background renderer."""
+        if self._stopped:
+            return
+        self._renderer.submit(text, markdown_cls)
 
     def stop(self, *, keep: bool = True) -> None:
-        """End the live region.
+        """End the live region. Idempotent.
 
         Parameters
         ----------
         keep : bool
-            If True, render the final content through Rich and push
-            it to history as a ``"response"`` item with a bullet.
+            If True, push the final un-spilled tail into history as a
+            ``"response"`` (with bullet) or ``"rich"`` item depending on
+            whether earlier spill chunks already received the bullet.
+
+        Order matters here: the history append must precede the stream
+        clear so pyink's batched render shows the response transitioning
+        from the dynamic area into scrollback in a single frame, with
+        no blank-frame flicker.
         """
-        # Clear stream and phase first, then add to history.
-        # All three set_state calls batch into one render cycle
-        # (schedule_update only queues one call_soon_threadsafe).
+        if self._stopped:
+            return
+        self._stopped = True
+        final_ansi, item_type = self._renderer.stop(keep=keep)
+        if keep and final_ansi:
+            self._set_history(
+                lambda h, a=final_ansi, t=item_type: [
+                    *h, {"type": t, "ansi": a},
+                ],
+            )
         self._set_stream("")
         self._set_phase("idle")
-        if keep and self._last_renderable is not None:
-            ansi = rich_to_ansi(self._console, self._last_renderable)
-            if ansi:
-                self._set_history(lambda h: [*h, {"type": "response", "ansi": ansi}])
 
 
 class InkWriter:
@@ -401,6 +596,7 @@ class InkWriter:
         self._set_phase = set_phase
         self._console = console
         self._approval_callback = approval_callback
+        self._active_live: _InkLiveHandle | None = None
 
     def print_rich(self, *args: Any, item_type: str | None = None, **kwargs: Any) -> None:
         """Render Rich content and append to history.
@@ -445,16 +641,31 @@ class InkWriter:
         """
         self._set_phase("streaming")
         self._set_stream("")
-        return _InkLiveHandle(
+        handle = _InkLiveHandle(
             self._set_stream,
             self._set_phase,
             self._set_history,
             self._console,
         )
+        self._active_live = handle
+        return handle
 
     def stop_live(self, handle: _InkLiveHandle, *, keep: bool = True) -> None:
         """Stop the live region, optionally freezing content to history."""
         handle.stop(keep=keep)
+        if self._active_live is handle:
+            self._active_live = None
+
+    def cancel_live(self) -> None:
+        """Pre-empt any active live region without freezing it to history.
+
+        Called from the input handler on Ctrl+C so the renderer thread
+        stops pushing tokens immediately and the live tail clears.
+        """
+        handle = self._active_live
+        if handle is not None:
+            handle.stop(keep=False)
+            self._active_live = None
 
     async def prompt_input(self, label: str) -> str:
         """Prompt user for input via the selector UI.

--- a/orxhestra/integrations/mcp/adapter.py
+++ b/orxhestra/integrations/mcp/adapter.py
@@ -66,18 +66,21 @@ def _build_input_model(tool_name: str, json_schema: dict[str, Any]) -> type[Base
     return create_model(f"{tool_name}Input", **fields)
 
 
-def _json_type_to_python(json_type: str) -> type:
-    """Map a JSON Schema type string to a Python type.
+def _json_type_to_python(json_type: str | list[str]) -> type:
+    """Map a JSON Schema type to a Python type.
 
     Parameters
     ----------
-    json_type : str
-        A JSON Schema primitive type name.
+    json_type : str or list[str]
+        A JSON Schema primitive type name, or the array-of-types form
+        (``["string", "null"]``) that draft-07+ uses to express nullable
+        or union-typed fields.
 
     Returns
     -------
     type
-        The corresponding Python type, defaulting to str.
+        The corresponding Python type. Lists collapse to their first
+        non-"null" entry; unknown types default to ``str``.
     """
     mapping = {
         "string": str,
@@ -87,6 +90,11 @@ def _json_type_to_python(json_type: str) -> type:
         "array": list,
         "object": dict,
     }
+    if isinstance(json_type, list):
+        non_null = [t for t in json_type if t != "null"]
+        if not non_null:
+            return type(None)
+        json_type = non_null[0]
     return mapping.get(json_type, str)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ auth = ["cryptography>=43.0", "base58>=2.1", "PyJWT>=2.8"]
 database = ["sqlalchemy[asyncio]>=2.0", "aiosqlite>=0.20"]
 mcp = ["fastmcp>=2.0.0"]
 composer = ["pyyaml>=6.0"]
-cli = ["rich>=13.0", "pyyaml>=6.0", "pyinklib>=1.1.15"]
+cli = ["rich>=13.0", "pyyaml>=6.0", "pyinklib>=1.1.16"]
 all = [
     "fastapi>=0.115.0",
     "langchain-openai>=1.1.11",
@@ -59,7 +59,7 @@ all = [
     "fastmcp>=2.0.0",
     "pyyaml>=6.0",
     "rich>=13.0",
-    "pyinklib>=1.1.15",
+    "pyinklib>=1.1.16",
     "sqlalchemy[asyncio]>=2.0",
     "aiosqlite>=0.20",
     "cryptography>=43.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ auth = ["cryptography>=43.0", "base58>=2.1", "PyJWT>=2.8"]
 database = ["sqlalchemy[asyncio]>=2.0", "aiosqlite>=0.20"]
 mcp = ["fastmcp>=2.0.0"]
 composer = ["pyyaml>=6.0"]
-cli = ["rich>=13.0", "pyyaml>=6.0", "pyinklib>=1.1.16"]
+cli = ["rich>=13.0", "pyyaml>=6.0", "pyinklib>=1.1.17"]
 all = [
     "fastapi>=0.115.0",
     "langchain-openai>=1.1.11",
@@ -59,7 +59,7 @@ all = [
     "fastmcp>=2.0.0",
     "pyyaml>=6.0",
     "rich>=13.0",
-    "pyinklib>=1.1.16",
+    "pyinklib>=1.1.17",
     "sqlalchemy[asyncio]>=2.0",
     "aiosqlite>=0.20",
     "cryptography>=43.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orxhestra"
-version = "0.1.6"
+version = "0.1.7"
 description = "Multi-Agent Orchestration Framework for Python"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- **REPL responsiveness under heavy streaming output** — moved Rich→ANSI conversion to a daemon scheduler thread with single-slot mailbox, windowed live tail, and spill-to-scrollback so per-frame render work stays bounded regardless of response size. Ctrl+C and the selector stay reachable under any load.
- **Deadlock-safe input queue** — messages typed during streaming float in a dynamic area, get drained into history when the worker takes them, and only the last queued message fires a new completion (intermediate ones are preserved as user-line history).
- **No end-of-stream blink** — scheduler skips its final `set_stream` once `stop()` is called; `stop()` pushes the response into history before clearing the dynamic stream so pyink batches the handoff into one frame.
- **Multi-line input** — Shift+Enter (with kitty keyboard protocol), Alt/Option+Enter, Ctrl+J (universal — pyink 1.1.16 disambiguates from plain Enter), and `\` + Enter (universal fallback) all insert a newline. Multi-line buffers render under one ❯ prompt; up/down arrows move between lines first and only fall through to history at the top/bottom edge; Home/End jump to the start/end of the current line.
- **MCP adapter** — handle JSON Schema array-of-types (`["string", "null"]`) draft-07+ form which previously crashed on the unhashable-list dict lookup.

## Test plan
- [ ] Long agent response — input + Ctrl+C stay responsive throughout streaming.
- [ ] Type during streaming — message floats below stream, lands in scrollback when worker drains, only the last queued msg triggers a new completion.
- [ ] Ctrl+C mid-stream with queued messages — queue clears, no zombie dispatches.
- [ ] Multi-line input — Ctrl+J or `\Enter` inserts a newline; plain Enter submits the multi-line message.
- [ ] MCP tool with nullable input — no crash on adapter import.