### PR TITLE
v0.1.8 — /agent command + reasoning effort + gpt-5.5 default

### DIFF
--- a/orxhestra/__init__.py
+++ b/orxhestra/__init__.py
@@ -47,7 +47,7 @@ Identity / trust / attestation (opt-in, requires ``orxhestra[auth]``)::
     )
 """
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 from orxhestra.agents import (
     AgentConfig,

--- a/orxhestra/cli/app.py
+++ b/orxhestra/cli/app.py
@@ -33,7 +33,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from orxhestra.cli.config import DEFAULT_MODEL
+from orxhestra.cli.config import DEFAULT_EFFORT, DEFAULT_MODEL
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -91,6 +91,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "-m", "--model",
         default=os.environ.get("ORX_MODEL", DEFAULT_MODEL),
         help=f"Model name (default: {DEFAULT_MODEL}). Also reads $ORX_MODEL.",
+    )
+    parser.add_argument(
+        "-e", "--effort",
+        choices=["low", "medium", "high"],
+        default=os.environ.get("ORX_EFFORT", DEFAULT_EFFORT),
+        help=(
+            f"Reasoning effort: low (fast) | medium | high (default: "
+            f"{DEFAULT_EFFORT}). Translated per-provider — OpenAI uses "
+            "reasoning_effort, Anthropic uses thinking budget, Google uses "
+            "thinking_level. Also reads $ORX_EFFORT."
+        ),
     )
     parser.add_argument(
         "-w", "--workspace",
@@ -385,7 +396,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     from orxhestra.cli.builder import build_from_orx
 
     state: ReplState = await build_from_orx(
-        orx_path, args.model, args.workspace
+        orx_path, args.model, args.workspace, effort=args.effort,
     )
     state.auto_approve = args.auto_approve
 

--- a/orxhestra/cli/builder.py
+++ b/orxhestra/cli/builder.py
@@ -81,6 +81,8 @@ async def build_from_orx(
     orx_path: Path,
     model_name: str,
     workspace: str,
+    *,
+    effort: str | None = None,
 ) -> ReplState:
     """Build a Runner from an orx YAML and return populated ReplState.
 
@@ -113,7 +115,7 @@ async def build_from_orx(
         sys.exit(1)
 
     os.environ["AGENT_WORKSPACE"] = workspace
-    model = create_llm(model_name)
+    model = create_llm(model_name, effort=effort)
     register_cli_builtins(workspace, model)
 
     with open(orx_path) as f:
@@ -124,10 +126,16 @@ async def build_from_orx(
     if "model" not in defaults:
         if "defaults" not in raw:
             raw["defaults"] = {}
-        raw["defaults"]["model"] = {
-            "provider": detect_provider(model_name),
+        from orxhestra.cli.config import effort_model_kwargs
+
+        provider = detect_provider(model_name)
+        model_spec: dict = {
+            "provider": provider,
             "name": model_name,
         }
+        if effort:
+            model_spec.update(effort_model_kwargs(provider, effort))
+        raw["defaults"]["model"] = model_spec
     else:
         # Use the YAML model name for the banner display.
         yaml_model = defaults["model"]
@@ -180,6 +188,8 @@ async def build_from_orx(
         runner=runner,
         session_id=str(uuid4()),
         model_name=model_name,
+        effort=effort,
+        spec_raw=raw,
         todo_list=get_todo_list(),
         model=model,
     )

--- a/orxhestra/cli/commands.py
+++ b/orxhestra/cli/commands.py
@@ -647,16 +647,27 @@ async def _cmd_agent(
     sub_disp = ", ".join(sub_agents) if sub_agents else "[orx.muted]—[/orx.muted]"
     type_disp = a.get("type") or "[orx.muted]—[/orx.muted]"
 
+    from rich.table import Table
+
     writer.print_rich(f"[orx.accent]❯ {name}[/orx.accent]")
     writer.print_rich(
-        "[orx.muted]  ─────────────────────────────────────────────[/orx.muted]"
+        "[orx.muted]─────────────────────────────────────────────[/orx.muted]"
     )
-    writer.print_rich(f"  [orx.help.cmd]type[/orx.help.cmd]         {type_disp}")
-    writer.print_rich(f"  [orx.help.cmd]model[/orx.help.cmd]        {model_disp}")
-    writer.print_rich(f"  [orx.help.cmd]effort[/orx.help.cmd]       {effort_disp}")
-    writer.print_rich(f"  [orx.help.cmd]description[/orx.help.cmd]  {description}")
-    writer.print_rich(f"  [orx.help.cmd]tools[/orx.help.cmd]        {tools_disp}")
-    writer.print_rich(f"  [orx.help.cmd]sub-agents[/orx.help.cmd]   {sub_disp}")
+    detail = Table(
+        show_header=False,
+        box=None,
+        pad_edge=False,
+        padding=(0, 2),
+    )
+    detail.add_column(style="orx.help.cmd")
+    detail.add_column(overflow="fold")
+    detail.add_row("type", type_disp)
+    detail.add_row("model", model_disp)
+    detail.add_row("effort", effort_disp)
+    detail.add_row("description", description)
+    detail.add_row("tools", tools_disp)
+    detail.add_row("sub-agents", sub_disp)
+    writer.print_rich(detail)
 
 
 async def _cmd_help(

--- a/orxhestra/cli/commands.py
+++ b/orxhestra/cli/commands.py
@@ -33,6 +33,7 @@ _DESC: str = "orx.help.desc"
 _HELP_TEXT: str = (
     f"[{_CMD}]Commands:[/{_CMD}]\n"
     f"  [{_CMD}]/model <name>[/{_CMD}]  [{_DESC}]Switch model[/{_DESC}]\n"
+    f"  [{_CMD}]/agent [name][/{_CMD}]  [{_DESC}]List agents or show one[/{_DESC}]\n"
     f"  [{_CMD}]/clear[/{_CMD}]         [{_DESC}]Clear session[/{_DESC}]\n"
     f"  [{_CMD}]/compact[/{_CMD}]       [{_DESC}]Compact context[/{_DESC}]\n"
     f"  [{_CMD}]/todos[/{_CMD}]         [{_DESC}]Show tasks[/{_DESC}]\n"
@@ -530,6 +531,134 @@ async def _cmd_theme(
     )
 
 
+def _agent_model_effort(
+    spec_raw: dict, name: str,
+) -> tuple[str | None, str | None]:
+    """Pull the model name + effort an agent declares (if any).
+
+    Returns ``(None, None)`` when the agent inherits both from defaults.
+    """
+    agents: dict = spec_raw.get("agents", {}) or {}
+    a: dict = agents.get(name) or {}
+    model_name: str | None = None
+    raw_model = a.get("model")
+    if isinstance(raw_model, dict):
+        model_name = raw_model.get("name")
+    elif isinstance(raw_model, str):
+        model_name = raw_model
+    effort: str | None = a.get("effort")
+    if effort is None and isinstance(raw_model, dict):
+        effort = raw_model.get("effort")
+        if effort is None:
+            re = raw_model.get("reasoning_effort")
+            if isinstance(re, str):
+                effort = re
+    return model_name, effort
+
+
+def _agent_tools(spec_raw: dict, name: str) -> list[str]:
+    """Best-effort extraction of an agent's tool names from raw YAML."""
+    agents: dict = spec_raw.get("agents", {}) or {}
+    a: dict = agents.get(name) or {}
+    tools = a.get("tools")
+    if isinstance(tools, list):
+        return [str(t) for t in tools]
+    if isinstance(tools, dict):
+        return list(tools.keys())
+    return []
+
+
+async def _cmd_agent(
+    state: ReplState,
+    cmd_arg: str | None,
+    *,
+    writer: Writer,
+    **_kw: object,
+) -> None:
+    """Show the agent roster or details for a specific agent.
+
+    With no argument: a one-line table of every agent's effective
+    model and effort, plus its tool count. With a name argument:
+    full details for that agent (description, model, effort, tools,
+    sub-agents).
+    """
+    spec: dict = state.spec_raw or {}
+    agents: dict = spec.get("agents", {}) or {}
+    if not agents:
+        writer.print_rich(
+            "[orx.status]No agents defined in this orx file.[/orx.status]"
+        )
+        return
+
+    default_model = state.model_name
+    default_effort = state.effort or "—"
+
+    if not cmd_arg:
+        from rich.table import Table
+
+        table = Table(
+            show_header=True,
+            header_style="orx.help.cmd",
+            box=None,
+            pad_edge=False,
+            padding=(0, 2),
+        )
+        table.add_column("agent")
+        table.add_column("model")
+        table.add_column("effort")
+        table.add_column("tools")
+        for name in agents:
+            m, e = _agent_model_effort(spec, name)
+            model_cell = m or "[orx.muted](default)[/orx.muted]"
+            effort_cell = e or "[orx.muted](default)[/orx.muted]"
+            tools = _agent_tools(spec, name)
+            if tools:
+                tools_cell = ", ".join(tools[:3]) + (
+                    f", +{len(tools) - 3}" if len(tools) > 3 else ""
+                )
+            else:
+                tools_cell = "[orx.muted]—[/orx.muted]"
+            table.add_row(name, model_cell, effort_cell, tools_cell)
+        writer.print_rich(table)
+        writer.print_rich(
+            f"[orx.muted]defaults: {default_model} · effort {default_effort}"
+            f"  ·  /agent <name> for details[/orx.muted]"
+        )
+        return
+
+    name = cmd_arg.strip()
+    if name not in agents:
+        writer.print_rich(
+            f"[orx.status]Unknown agent: {name}. "
+            f"Try /agent for the list.[/orx.status]"
+        )
+        return
+
+    a: dict = agents.get(name) or {}
+    m, e = _agent_model_effort(spec, name)
+    model_disp = m or f"{default_model} [orx.muted](default)[/orx.muted]"
+    effort_disp = e or f"{default_effort} [orx.muted](default)[/orx.muted]"
+    description = a.get("description") or "[orx.muted]—[/orx.muted]"
+    tools = _agent_tools(spec, name)
+    tools_disp = ", ".join(tools) if tools else "[orx.muted]—[/orx.muted]"
+    sub_agents = a.get("sub_agents") or a.get("agents") or []
+    if isinstance(sub_agents, dict):
+        sub_agents = list(sub_agents.keys())
+    sub_disp = ", ".join(sub_agents) if sub_agents else "[orx.muted]—[/orx.muted]"
+    type_disp = a.get("type") or "[orx.muted]—[/orx.muted]"
+
+    writer.print_rich(f"[orx.accent]❯ {name}[/orx.accent]")
+    writer.print_rich(
+        "[orx.muted]  ─────────────────────────────────────────────[/orx.muted]"
+    )
+    writer.print_rich(f"  [orx.help.cmd]type[/orx.help.cmd]         {type_disp}")
+    writer.print_rich(f"  [orx.help.cmd]model[/orx.help.cmd]        {model_disp}")
+    writer.print_rich(f"  [orx.help.cmd]effort[/orx.help.cmd]       {effort_disp}")
+    writer.print_rich(f"  [orx.help.cmd]description[/orx.help.cmd]  {description}")
+    writer.print_rich(f"  [orx.help.cmd]tools[/orx.help.cmd]        {tools_disp}")
+    writer.print_rich(f"  [orx.help.cmd]sub-agents[/orx.help.cmd]   {sub_disp}")
+
+
 async def _cmd_help(
     _state: ReplState,
     _cmd_arg: str | None,
@@ -556,6 +685,7 @@ _DISPATCH: dict[str, Callable[..., object]] = {
     "/clear": _cmd_clear,
     "/compact": _cmd_compact,
     "/model": _cmd_model,
+    "/agent": _cmd_agent,
     "/todos": _cmd_todos,
     "/session": _cmd_session,
     "/undo": _cmd_undo,

--- a/orxhestra/cli/config.py
+++ b/orxhestra/cli/config.py
@@ -13,9 +13,43 @@ from pathlib import Path
 
 APP_NAME: str = "orx-cli"
 DEFAULT_USER_ID: str = "cli-user"
-DEFAULT_MODEL: str = os.environ.get("ORX_MODEL", "gpt-5.4")
+DEFAULT_MODEL: str = os.environ.get("ORX_MODEL", "gpt-5.5")
+DEFAULT_EFFORT: str = os.environ.get("ORX_EFFORT", "medium")
 HISTORY_DIR: Path = Path.home() / ".orx"
 HISTORY_FILE: Path = HISTORY_DIR / "history"
+
+# Anthropic / Cohere thinking budgets, indexed by unified effort level.
+_ANTHROPIC_THINKING_BUDGET: dict[str, int | None] = {
+    "low": None,
+    "medium": 5000,
+    "high": 10000,
+}
+
+
+def effort_model_kwargs(provider: str, effort: str) -> dict[str, object]:
+    """Return provider-specific model kwargs for a reasoning effort level.
+
+    Maps a unified ``"low" / "medium" / "high"`` effort level to the
+    parameter shape each provider expects:
+
+    - Anthropic / Bedrock / Cohere: ``thinking.budget_tokens``
+    - OpenAI / Azure OpenAI: ``reasoning_effort`` (+ Responses API)
+    - Google / Vertex: ``thinking_level``
+    - xAI / DeepSeek / Mistral / Groq: ``reasoning_effort``
+    - All others: empty (silently ignored)
+    """
+    if provider in ("anthropic", "aws", "bedrock", "aws_bedrock", "cohere"):
+        budget = _ANTHROPIC_THINKING_BUDGET.get(effort)
+        if budget is None:
+            return {}
+        return {"thinking": {"type": "enabled", "budget_tokens": budget}}
+    if provider in ("openai", "azure", "azure_openai", "azure_ai"):
+        return {"reasoning_effort": effort, "use_responses_api": True}
+    if provider in ("google", "google_genai", "google_vertexai", "vertexai"):
+        return {"thinking_level": effort}
+    if provider in ("xai", "deepseek", "mistralai", "mistral", "groq"):
+        return {"reasoning_effort": effort}
+    return {}
 
 # Provider detection: prefix -> provider name for model registry.
 # Order matters — first match wins.

--- a/orxhestra/cli/ink_app.py
+++ b/orxhestra/cli/ink_app.py
@@ -682,6 +682,7 @@ def run_ink_app(
             state.model_name,
             workspace,
             signer_did=state.signer_did,
+            effort=state.effort,
         ),
     )
 

--- a/orxhestra/cli/models.py
+++ b/orxhestra/cli/models.py
@@ -42,7 +42,7 @@ def detect_provider(model_name: str) -> str:
     return "openai"
 
 
-def create_llm(model_name: str) -> BaseChatModel:
+def create_llm(model_name: str, effort: str | None = None) -> BaseChatModel:
     """Create a LangChain BaseChatModel from a model name string.
 
     Raises a clear error if the provider package is missing or if
@@ -52,6 +52,10 @@ def create_llm(model_name: str) -> BaseChatModel:
     ----------
     model_name : str
         Model name string used to detect the provider and instantiate the model.
+    effort : str or None, optional
+        Unified reasoning effort (``"low"``, ``"medium"``, ``"high"``).
+        Translated per-provider via :func:`effort_model_kwargs`. ``None``
+        leaves the model defaults untouched.
 
     Returns
     -------
@@ -65,10 +69,13 @@ def create_llm(model_name: str) -> BaseChatModel:
         msg = f"Missing {env_var}. Set it with: export {env_var}=sk-..."
         raise RuntimeError(msg)
 
+    from orxhestra.cli.config import effort_model_kwargs
     from orxhestra.composer.builders.models import create
 
+    extra: dict = effort_model_kwargs(provider, effort) if effort else {}
+
     try:
-        return create(provider, model_name)
+        return create(provider, model_name, **extra)
     except Exception as exc:
         hint: str = PROVIDER_INSTALL_HINTS.get(provider, "")
         msg = f"Failed to create model '{model_name}' ({provider}): {exc}"

--- a/orxhestra/cli/orx.yaml
+++ b/orxhestra/cli/orx.yaml
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   orx                     # loads this template
-#   orx --model gpt-5.4     # override the model
+#   orx --model gpt-5.5     # override the model
 #
 # To customise, copy this file and run: orx my-orx.yaml
 
@@ -15,7 +15,7 @@ version: "0.0.21"
 defaults:
   model:
     provider: openai
-    name: gpt-5.4
+    name: gpt-5.5
 
 tools:
   filesystem:

--- a/orxhestra/cli/render.py
+++ b/orxhestra/cli/render.py
@@ -239,6 +239,7 @@ def render_banner(
     model_name: str,
     workspace: str,
     signer_did: str | None = None,
+    effort: str | None = None,
 ) -> Any:
     """Return a Rich renderable for the welcome banner.
 
@@ -312,9 +313,15 @@ def render_banner(
             f"\n[{lbl}]identity:[/{lbl}]  "
             f"[orx.muted]disabled (pass --identity to enable)[/orx.muted]"
         )
+    model_row: str = f"[{lbl}]model:[/{lbl}]     {model_name}"
+    if effort:
+        model_row += (
+            f"  [orx.muted]·[/orx.muted]  "
+            f"[{lbl}]effort:[/{lbl}] {effort}"
+        )
     content: str = (
         f"[orx.accent]orx[/orx.accent] {ver}\n"
-        f"[{lbl}]model:[/{lbl}]     {model_name}\n"
+        f"{model_row}\n"
         f"[{lbl}]workspace:[/{lbl}] {ws_display}\n"
         f"[{lbl}]agents:[/{lbl}]    {agent_names}"
         f"{identity_row}"

--- a/orxhestra/cli/state.py
+++ b/orxhestra/cli/state.py
@@ -52,6 +52,17 @@ class ReplState(BaseModel):
     runner: Runner = Field(description="Active Runner instance for agent execution.")
     session_id: str = Field(description="Current session identifier.")
     model_name: str = Field(description="Name of the LLM model in use.")
+    effort: str | None = Field(
+        default=None,
+        description="Active reasoning effort level (low|medium|high).",
+    )
+    spec_raw: dict | None = Field(
+        default=None,
+        description=(
+            "Parsed orx YAML used to build the agent tree. Drives the "
+            "/agent command's per-agent introspection."
+        ),
+    )
     todo_list: TodoList | None = Field(
         default=None, description="Active todo list for task tracking."
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orxhestra"
-version = "0.1.7"
+version = "0.1.8"
 description = "Multi-Agent Orchestration Framework for Python"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- **Default model bumped to gpt-5.5** (override via `--model` / `$ORX_MODEL`).
- **New `--effort` flag** (low | medium | high, default medium). Translates per-provider: `reasoning_effort` for OpenAI/Azure/xAI/DeepSeek/Mistral/Groq, `thinking.budget_tokens` for Anthropic/Bedrock/Cohere, `thinking_level` for Google. Override via `$ORX_EFFORT`.
- **Banner shows effort** alongside the model on a single row: `model: gpt-5.5 · effort: medium`.
- **New `/agent` command** — list every agent in a Rich table (model, effort, tools), or `/agent <name>` for a detail view. Per-agent model/effort overrides surface here instead of cluttering the banner.

## Test plan
- [ ] `orx --help` shows `--effort` choices.
- [ ] Banner renders the effort suffix.
- [ ] `/agent` prints the table; `/agent coder` prints the detail view; both columns align.
- [ ] `--effort high` reaches the underlying LangChain model (verify per-provider).